### PR TITLE
[cmake] reorganize cmake for CUDA

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ if (cga_enable_benchmarks)
     set_property(GLOBAL PROPERTY enable_benchmarks ON)
 endif()
 
+include(cmake/CUDA.cmake)
 include(cmake/Doxygen.cmake)
 include(cmake/3rdparty.cmake)
 include(cmake/Tests.cmake)

--- a/cmake/3rdparty.cmake
+++ b/cmake/3rdparty.cmake
@@ -8,8 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
-
 # Add 3rd party build dependencies.
 if (NOT TARGET bioparser)
     add_subdirectory(3rdparty/bioparser EXCLUDE_FROM_ALL)

--- a/cmake/Benchmarks.cmake
+++ b/cmake/Benchmarks.cmake
@@ -8,8 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
-
 get_property(enable_benchmarks GLOBAL PROPERTY enable_benchmarks)
 function(cga_add_benchmarks NAME MODULE SOURCES LIBS)
     # Add test executable

--- a/cmake/CUDA.cmake
+++ b/cmake/CUDA.cmake
@@ -8,7 +8,13 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-set(CUDAPOA_BENCHMARK_DATA_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../data")
-configure_file(file_location.hpp.in ${PROJECT_BINARY_DIR}/data/file_location.hpp @ONLY)
+# Check CUDA dependency for project.
+find_package(CUDA 9.0 QUIET REQUIRED)
 
-set_property(GLOBAL PROPERTY cudapoa_data_include_dir "${PROJECT_BINARY_DIR}/data")
+if(NOT ${CUDA_FOUND})
+    message(FATAL_ERROR "CUDA not detected on system. Please install")
+else()
+    message(STATUS "Using CUDA ${CUDA_VERSION} from ${CUDA_TOOLKIT_ROOT_DIR}")
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -lineinfo -use_fast_math -Xcompiler -Wall,-Wno-pedantic")
+endif()
+

--- a/cmake/Doxygen.cmake
+++ b/cmake/Doxygen.cmake
@@ -8,8 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
-
 set_property(GLOBAL PROPERTY doxygen_src_dirs)
 set_property(GLOBAL PROPERTY doxygen_mainpage)
 function(add_doxygen_source_dir)

--- a/cmake/Tests.cmake
+++ b/cmake/Tests.cmake
@@ -8,9 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
-
-
 #Cmake macro to initialzie ctest.
 enable_testing()
 

--- a/cudaaligner/CMakeLists.txt
+++ b/cudaaligner/CMakeLists.txt
@@ -8,17 +8,10 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(cudaaligner)
 
-find_package(CUDA 9.0 QUIET REQUIRED)
-
-if(NOT ${CUDA_FOUND})
-    message(FATAL_ERROR "CUDA not detected on system. Please install")
-else()
-    message(STATUS "Using CUDA ${CUDA_VERSION} from ${CUDA_TOOLKIT_ROOT_DIR}")
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -lineinfo --expt-relaxed-constexpr -use_fast_math -Xcompiler -Wno-pedantic,-Wall -std=c++14")
-endif()
+# Project specific NVCC flags
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++14 --expt-relaxed-constexpr")
 
 cuda_add_library(cudaaligner STATIC 
     src/cudaaligner.cpp

--- a/cudaaligner/benchmarks/singlealignment/CMakeLists.txt
+++ b/cudaaligner/benchmarks/singlealignment/CMakeLists.txt
@@ -18,7 +18,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(singlealignment)
 
 set(SOURCES

--- a/cudaaligner/benchmarks/singlebatchalignment/CMakeLists.txt
+++ b/cudaaligner/benchmarks/singlebatchalignment/CMakeLists.txt
@@ -18,7 +18,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(singlebatchalignment)
 
 set(SOURCES

--- a/cudaaligner/tests/CMakeLists.txt
+++ b/cudaaligner/tests/CMakeLists.txt
@@ -8,7 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(cudaalignertests)
 
 set(SOURCES

--- a/cudapoa/CMakeLists.txt
+++ b/cudapoa/CMakeLists.txt
@@ -8,20 +8,13 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(cudapoa)
 
 # Process data subdirectory first
 add_subdirectory(data)
 
-find_package(CUDA 9.0 QUIET REQUIRED)
-
-if(NOT ${CUDA_FOUND})
-    message(FATAL_ERROR "CUDA not detected on system. Please install")
-else()
-    message(STATUS "Using CUDA ${CUDA_VERSION} from ${CUDA_TOOLKIT_ROOT_DIR}")
-    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11 -lineinfo -use_fast_math -Xcompiler -Wall,-Wno-pedantic")
-endif()
+# Project specific NVCC flags
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -std=c++11")
 
 cuda_add_library(cudapoa STATIC 
     src/cudapoa.cpp

--- a/cudapoa/benchmarks/multi-batch/CMakeLists.txt
+++ b/cudapoa/benchmarks/multi-batch/CMakeLists.txt
@@ -18,7 +18,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(multibatch)
 
 set(SOURCES

--- a/cudapoa/benchmarks/single-batch/CMakeLists.txt
+++ b/cudapoa/benchmarks/single-batch/CMakeLists.txt
@@ -18,7 +18,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(singlebatch)
 
 set(SOURCES

--- a/cudapoa/tests/CMakeLists.txt
+++ b/cudapoa/tests/CMakeLists.txt
@@ -8,7 +8,6 @@
 # license agreement from NVIDIA CORPORATION is strictly prohibited.
 #
 
-cmake_minimum_required(VERSION 3.10.2)
 project(cudapoatests)
 
 set(SOURCES


### PR DESCRIPTION
1. Move CUDA specific settings into its own file
2. Removed duplicate cmake min version requirements