### PR TITLE
[common] Use gtest *_EQ on std::strings

### DIFF
--- a/cudaaligner/tests/Test_AlignerGlobal.cpp
+++ b/cudaaligner/tests/Test_AlignerGlobal.cpp
@@ -174,8 +174,8 @@ TEST_P(TestAlignerGlobal, TestAlignmentKernel)
         auto alignment = alignments[a];
         EXPECT_EQ(StatusType::success, alignment->get_status()) << "Alignment status is not success";
         EXPECT_EQ(AlignmentType::global, alignment->get_alignment_type()) << "Alignment type is not global";
-        EXPECT_STREQ(cigars[a].c_str(), alignment->convert_to_cigar().c_str()) << "CIGAR doesn't match for alignment " << a
-                                                                               << " using " << (param.algorithm == AlignmentAlgorithm::Ukkonen ? "Ukkonen" : "Myers");
+        EXPECT_EQ(cigars[a], alignment->convert_to_cigar()) << "CIGAR doesn't match for alignment " << a
+                                                            << " using " << (param.algorithm == AlignmentAlgorithm::Ukkonen ? "Ukkonen" : "Myers");
     }
 }
 

--- a/cudaaligner/tests/Test_AlignmentImpl.cpp
+++ b/cudaaligner/tests/Test_AlignmentImpl.cpp
@@ -142,11 +142,8 @@ protected:
 
 TEST_P(TestAlignmentImpl, StringGetters)
 {
-    ASSERT_STREQ(param_.query.c_str(), alignment_->get_query_sequence().c_str()) << "Query doesn't match original string";
-    ASSERT_EQ(param_.query.size(), alignment_->get_query_sequence().size()) << "Query length match original string";
-
-    ASSERT_STREQ(param_.subject.c_str(), alignment_->get_subject_sequence().c_str()) << "Subject doesn't match original string";
-    ASSERT_EQ(param_.subject.size(), alignment_->get_subject_sequence().size()) << "Subject length match original string";
+    ASSERT_EQ(param_.query, alignment_->get_query_sequence()) << "Query doesn't match original string";
+    ASSERT_EQ(param_.subject, alignment_->get_subject_sequence()) << "Subject doesn't match original string";
 }
 
 TEST_P(TestAlignmentImpl, AlignmentState)
@@ -164,14 +161,14 @@ TEST_P(TestAlignmentImpl, AlignmentFormatting)
     FormattedAlignment formatted_alignment = alignment_->format_alignment();
     std::string query                      = formatted_alignment.first;
     std::string subject                    = formatted_alignment.second;
-    ASSERT_STREQ(param_.formatted_alignment.first.c_str(), query.c_str());
-    ASSERT_STREQ(param_.formatted_alignment.second.c_str(), subject.c_str());
+    ASSERT_EQ(param_.formatted_alignment.first, query);
+    ASSERT_EQ(param_.formatted_alignment.second, subject);
 }
 
 TEST_P(TestAlignmentImpl, CigarFormatting)
 {
     std::string cigar = alignment_->convert_to_cigar();
-    ASSERT_STREQ(param_.cigar.c_str(), cigar.c_str());
+    ASSERT_EQ(param_.cigar, cigar);
 }
 
 INSTANTIATE_TEST_SUITE_P(TestAlignment, TestAlignmentImpl, ValuesIn(create_alignment_test_cases()));

--- a/cudapoa/tests/Test_CudapoaBatchEnd2End.cpp
+++ b/cudapoa/tests/Test_CudapoaBatchEnd2End.cpp
@@ -69,7 +69,7 @@ public:
 
         std::string golden_genome = parse_golden_value_file(param_.golden_file);
 
-        ASSERT_STREQ(golden_genome.c_str(), genome.c_str());
+        ASSERT_EQ(golden_genome, genome);
     }
 
 private:


### PR DESCRIPTION
Replaced the ASSERT_STREQ/EXPECT_STREQ with ASSERT_EQ/EXPECT_EQ for std::string.

*_STREQ is only required for c-strings, where you pass a pointer but want to compare content rather than the addresses.