### PR TITLE
[cudapoa] remove max poas arg from API

### DIFF
--- a/cudapoa/benchmarks/multi-batch/main.cpp
+++ b/cudapoa/benchmarks/multi-batch/main.cpp
@@ -26,9 +26,8 @@ namespace cudapoa
 static void BM_MultiBatchTest(benchmark::State& state)
 {
     int32_t batches             = state.range(0);
-    int32_t batch_size          = state.range(1);
     const int32_t total_windows = 5500;
-    MultiBatch mb(batches, batch_size, std::string(CUDAPOA_BENCHMARK_DATA_DIR) + "/sample-windows.txt", total_windows);
+    MultiBatch mb(batches, std::string(CUDAPOA_BENCHMARK_DATA_DIR) + "/sample-windows.txt", total_windows);
     for (auto _ : state)
     {
         mb.process_batches();
@@ -39,15 +38,9 @@ static void CustomArguments(benchmark::internal::Benchmark* b)
 {
     const int32_t min_total_windows = 512;
     const int32_t max_total_windows = 4096;
-    for (int32_t batches = 1; batches <= 64; batches *= 2)
+    for (int32_t batches = 1; batches <= 16; batches *= 2)
     {
-        for (int32_t batch_size = 64; batch_size <= 1024; batch_size *= 2)
-        {
-            if (batches * batch_size <= max_total_windows && batches * batch_size >= min_total_windows)
-            {
-                b->Args({batches, batch_size});
-            }
-        }
+        b->Args({batches});
     }
 }
 

--- a/cudapoa/benchmarks/multi-batch/multi_batch.hpp
+++ b/cudapoa/benchmarks/multi-batch/multi_batch.hpp
@@ -29,11 +29,9 @@ public:
     /// \brief Construct a multi batch processor
     ///
     /// \param num_batches Number of cudapoa batches
-    /// \param max_poas_per_batch Batch size
     /// \param filename Filename with window data
-    MultiBatch(int32_t num_batches, int32_t max_poas_per_batch, const std::string& filename, int32_t total_windows = -1)
+    MultiBatch(int32_t num_batches, const std::string& filename, int32_t total_windows = -1)
         : num_batches_(num_batches)
-        , max_poas_per_batch_(max_poas_per_batch)
     {
         parse_window_data_file(windows_, filename, total_windows);
 
@@ -47,7 +45,7 @@ public:
         {
             cudaStream_t stream;
             cudaStreamCreate(&stream);
-            batches_.emplace_back(create_batch(max_poas_per_batch, 200,
+            batches_.emplace_back(create_batch(200,
                                                0, mem_per_batch,
                                                OutputType::consensus,
                                                -8, -6, 8, false));
@@ -206,7 +204,6 @@ public:
 
 private:
     int32_t num_batches_;
-    int32_t max_poas_per_batch_;
     std::vector<std::unique_ptr<Batch>> batches_;
     std::vector<std::vector<std::string>> windows_;
     std::vector<std::string> consensus_;

--- a/cudapoa/benchmarks/single-batch/single_batch.hpp
+++ b/cudapoa/benchmarks/single-batch/single_batch.hpp
@@ -39,7 +39,7 @@ public:
         cudaSetDevice(0);
         cudaMemGetInfo(&free, &total);
         size_t mem_per_batch = 0.9 * free;
-        batch_               = create_batch(max_poas_per_batch, 200, 0, mem_per_batch, OutputType::consensus, -8, -6, 8, false);
+        batch_               = create_batch(200, 0, mem_per_batch, OutputType::consensus, -8, -6, 8, false);
         cudaStream_t stream;
         cudaStreamCreate(&stream);
         batch_->set_cuda_stream(stream);

--- a/cudapoa/include/claragenomics/cudapoa/batch.hpp
+++ b/cudapoa/include/claragenomics/cudapoa/batch.hpp
@@ -107,7 +107,6 @@ public:
 
 /// \brief Creates a new CUDA Batch object.
 ///
-/// \param max_poas Maximum number of POAs that can be added to the batch
 /// \param max_sequences_per_poa Maximum number of sequences per POA
 /// \param device_id GPU device on which to run CUDA POA algorithm
 /// \param max_mem Maximum GPU memory to use for this batch.
@@ -118,8 +117,7 @@ public:
 /// \param cuda_banded_alignment Whether to use banded alignment
 ///
 /// \return Returns a unique pointer to a new Batch object
-std::unique_ptr<Batch> create_batch(int32_t max_poas,
-                                    int32_t max_sequences_per_poa,
+std::unique_ptr<Batch> create_batch(int32_t max_sequences_per_poa,
                                     int32_t device_id,
                                     size_t max_mem,
                                     int8_t output_mask,

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -27,7 +27,7 @@ namespace cudapoa
 class BatchBlock
 {
 public:
-    BatchBlock(int32_t device_id_, size_t avail_mem, int32_t max_poas, int32_t max_sequences_per_poa, int8_t output_mask, bool banded_alignment = false);
+    BatchBlock(int32_t device_id_, size_t avail_mem, int32_t max_sequences_per_poa, int8_t output_mask, bool banded_alignment = false);
     ~BatchBlock();
 
     void get_output_details(OutputDetails** output_details_h_p, OutputDetails** output_details_d_p);
@@ -42,8 +42,15 @@ public:
 
     uint8_t* get_block_device();
 
+    int32_t get_max_poas() const { return max_poas_; };
+
 protected:
-    void calculate_size();
+    // Returns amount of host and device memory needed to store metadata per POA entry.
+    // The first two elements of the tuple are fixed host and device sizes that
+    // don't vary based on POA count. The latter two are host and device
+    // buffer sizes that scale with number of POA entries to process. These sizes do
+    // not include the scoring matrix needs for POA processing.
+    std::tuple<size_t, size_t, size_t, size_t> calculate_space_per_poa();
 
 protected:
     // Maximum POAs to process in batch.
@@ -60,15 +67,15 @@ protected:
     uint8_t* block_data_d_;
 
     // Accumulator for the memory size
-    uint64_t total_h_ = 0;
-    uint64_t total_d_ = 0;
+    size_t total_h_ = 0;
+    size_t total_d_ = 0;
 
     // Offset index for pointing a buffer to block memory
-    uint64_t offset_h_ = 0;
-    uint64_t offset_d_ = 0;
+    size_t offset_h_ = 0;
+    size_t offset_d_ = 0;
 
-    int32_t input_size_;
-    int32_t output_size_;
+    size_t input_size_;
+    size_t output_size_;
     int32_t matrix_sequence_dimension_;
     int32_t max_graph_dimension_;
     uint16_t max_nodes_per_window_;

--- a/cudapoa/src/batch.cpp
+++ b/cudapoa/src/batch.cpp
@@ -18,8 +18,7 @@ namespace claragenomics
 namespace cudapoa
 {
 
-std::unique_ptr<Batch> create_batch(int32_t max_poas,
-                                    int32_t max_sequences_per_poa,
+std::unique_ptr<Batch> create_batch(int32_t max_sequences_per_poa,
                                     int32_t device_id,
                                     size_t max_mem,
                                     int8_t output_mask,
@@ -28,7 +27,7 @@ std::unique_ptr<Batch> create_batch(int32_t max_poas,
                                     int16_t match_score,
                                     bool cuda_banded_alignment)
 {
-    return std::make_unique<CudapoaBatch>(max_poas, max_sequences_per_poa, device_id, max_mem, output_mask, gap_score, mismatch_score, match_score, cuda_banded_alignment);
+    return std::make_unique<CudapoaBatch>(max_sequences_per_poa, device_id, max_mem, output_mask, gap_score, mismatch_score, match_score, cuda_banded_alignment);
 }
 
 } // namespace cudapoa

--- a/cudapoa/src/cudapoa_batch.cpp
+++ b/cudapoa/src/cudapoa_batch.cpp
@@ -82,7 +82,11 @@ CudapoaBatch::CudapoaBatch(int32_t max_sequences_per_poa,
     , mismatch_score_(mismatch_score)
     , match_score_(match_score)
     , banded_alignment_(cuda_banded_alignment)
-    , batch_block_(new BatchBlock(device_id, max_mem, max_sequences_per_poa, output_mask, cuda_banded_alignment))
+    , batch_block_(new BatchBlock(device_id,
+                                  throw_on_negative(max_mem, "Maximum memory per batch has to be non-negative"),
+                                  max_sequences_per_poa,
+                                  output_mask,
+                                  cuda_banded_alignment))
     , max_poas_(batch_block_->get_max_poas())
 {
     bid_ = CudapoaBatch::batches++;

--- a/cudapoa/src/cudapoa_batch.cpp
+++ b/cudapoa/src/cudapoa_batch.cpp
@@ -67,8 +67,7 @@ void CudapoaBatch::initialize_graph_details()
     batch_block_->get_graph_details(&graph_details_d_);
 }
 
-CudapoaBatch::CudapoaBatch(int32_t max_poas,
-                           int32_t max_sequences_per_poa,
+CudapoaBatch::CudapoaBatch(int32_t max_sequences_per_poa,
                            int32_t device_id,
                            size_t max_mem,
                            int8_t output_mask,
@@ -76,15 +75,15 @@ CudapoaBatch::CudapoaBatch(int32_t max_poas,
                            int16_t mismatch_score,
                            int16_t match_score,
                            bool cuda_banded_alignment)
-    : max_poas_(throw_on_negative(max_poas, "Maximum POAs in batch has to be non-negative"))
-    , max_sequences_per_poa_(throw_on_negative(max_sequences_per_poa, "Maximum sequences per POA has to be non-negative"))
+    : max_sequences_per_poa_(throw_on_negative(max_sequences_per_poa, "Maximum sequences per POA has to be non-negative"))
     , device_id_(throw_on_negative(device_id, "Device ID has to be non-negative"))
     , output_mask_(output_mask)
     , gap_score_(gap_score)
     , mismatch_score_(mismatch_score)
     , match_score_(match_score)
     , banded_alignment_(cuda_banded_alignment)
-    , batch_block_(new BatchBlock(device_id, max_mem, max_poas, max_sequences_per_poa, output_mask, cuda_banded_alignment))
+    , batch_block_(new BatchBlock(device_id, max_mem, max_sequences_per_poa, output_mask, cuda_banded_alignment))
+    , max_poas_(batch_block_->get_max_poas())
 {
     bid_ = CudapoaBatch::batches++;
 

--- a/cudapoa/src/cudapoa_batch.hpp
+++ b/cudapoa/src/cudapoa_batch.hpp
@@ -45,7 +45,7 @@ class BatchBlock;
 class CudapoaBatch : public Batch
 {
 public:
-    CudapoaBatch(int32_t max_poas, int32_t max_sequences_per_poa, int32_t device_id, size_t max_mem, int8_t output_mask, int16_t gap_score = -8, int16_t mismatch_score = -6, int16_t match_score = 8, bool cuda_banded_alignment = false);
+    CudapoaBatch(int32_t max_sequences_per_poa, int32_t device_id, size_t max_mem, int8_t output_mask, int16_t gap_score = -8, int16_t mismatch_score = -6, int16_t match_score = 8, bool cuda_banded_alignment = false);
     ~CudapoaBatch();
 
     virtual StatusType add_poa_group(std::vector<StatusType>& per_seq_status,
@@ -105,9 +105,6 @@ protected:
     bool reserve_buf(uint32_t max_seq_length);
 
 protected:
-    // Maximum POAs to process in batch.
-    int32_t max_poas_ = 0;
-
     // Maximum sequences per POA.
     int32_t max_sequences_per_poa_ = 0;
 
@@ -165,6 +162,9 @@ protected:
 
     // Pointer of a seperate class BatchBlock that implements details on calculating and allocating the memory for each batch
     std::unique_ptr<BatchBlock> batch_block_;
+
+    // Maximum POAs to process in batch.
+    int32_t max_poas_ = 0;
 };
 
 /// \}

--- a/cudapoa/tests/Test_CudapoaBatch.cpp
+++ b/cudapoa/tests/Test_CudapoaBatch.cpp
@@ -28,18 +28,30 @@ public:
     }
 
     void initialize(int32_t max_sequences_per_poa,
-                    int32_t device_id      = 0,
+                    size_t mem_per_batch,
+                    int32_t device_id,
                     int8_t output_mask     = OutputType::consensus,
                     int16_t gap_score      = -8,
                     int16_t mismatch_score = -6,
                     int16_t match_score    = 8,
                     bool banded_alignment  = false)
     {
+        cudapoa_batch = claragenomics::cudapoa::create_batch(max_sequences_per_poa,
+                                                             device_id,
+                                                             mem_per_batch,
+                                                             output_mask,
+                                                             gap_score,
+                                                             mismatch_score,
+                                                             match_score,
+                                                             banded_alignment);
+    }
+
+    size_t get_free_device_mem(int32_t device_id)
+    {
         size_t total = 0, free = 0;
         cudaSetDevice(device_id);
         cudaMemGetInfo(&free, &total);
-        size_t mem_per_batch = 0.9 * free;
-        cudapoa_batch        = claragenomics::cudapoa::create_batch(max_sequences_per_poa, device_id, mem_per_batch, output_mask, gap_score, mismatch_score, match_score, banded_alignment);
+        return free;
     }
 
 public:
@@ -48,14 +60,24 @@ public:
 
 TEST_F(TestCudapoaBatch, InitializeTest)
 {
-    initialize(5);
+    const int32_t device_id = 0;
+    size_t free             = get_free_device_mem(device_id);
+    initialize(5, 0.9 * free, device_id);
     EXPECT_EQ(cudapoa_batch->batch_id(), 0);
     EXPECT_EQ(cudapoa_batch->get_total_poas(), 0);
 }
 
+TEST_F(TestCudapoaBatch, InitializeZeroMemTest)
+{
+    const int32_t device_id = 0;
+    EXPECT_THROW(initialize(5, 0, device_id), std::runtime_error);
+}
+
 TEST_F(TestCudapoaBatch, AddPOATest)
 {
-    initialize(5);
+    const int32_t device_id = 0;
+    size_t free             = get_free_device_mem(device_id);
+    initialize(5, 0.9 * free, device_id);
     Group poa_group;
     poa_group.push_back(Entry{});
     std::vector<StatusType> status;
@@ -68,7 +90,9 @@ TEST_F(TestCudapoaBatch, AddPOATest)
 
 TEST_F(TestCudapoaBatch, MaxSeqPerPOATest)
 {
-    initialize(10);
+    const int32_t device_id = 0;
+    size_t free             = get_free_device_mem(device_id);
+    initialize(10, 0.9 * free, device_id);
     Group poa_group;
     std::vector<StatusType> status;
 
@@ -90,7 +114,9 @@ TEST_F(TestCudapoaBatch, MaxSeqPerPOATest)
 
 TEST_F(TestCudapoaBatch, MaxSeqSizeTest)
 {
-    initialize(10);
+    const int32_t device_id = 0;
+    size_t free             = get_free_device_mem(device_id);
+    initialize(10, 0.9 * free, device_id);
     Group poa_group;
     std::vector<StatusType> status;
     Entry e{};

--- a/cudapoa/tests/Test_CudapoaBatch.cpp
+++ b/cudapoa/tests/Test_CudapoaBatch.cpp
@@ -27,8 +27,7 @@ public:
         // constructing test objects.
     }
 
-    void initialize(int32_t max_poas,
-                    int32_t max_sequences_per_poa,
+    void initialize(int32_t max_sequences_per_poa,
                     int32_t device_id      = 0,
                     int8_t output_mask     = OutputType::consensus,
                     int16_t gap_score      = -8,
@@ -40,7 +39,7 @@ public:
         cudaSetDevice(device_id);
         cudaMemGetInfo(&free, &total);
         size_t mem_per_batch = 0.9 * free;
-        cudapoa_batch        = claragenomics::cudapoa::create_batch(max_poas, max_sequences_per_poa, device_id, mem_per_batch, output_mask, gap_score, mismatch_score, match_score, banded_alignment);
+        cudapoa_batch        = claragenomics::cudapoa::create_batch(max_sequences_per_poa, device_id, mem_per_batch, output_mask, gap_score, mismatch_score, match_score, banded_alignment);
     }
 
 public:
@@ -49,14 +48,14 @@ public:
 
 TEST_F(TestCudapoaBatch, InitializeTest)
 {
-    initialize(5, 5);
+    initialize(5);
     EXPECT_EQ(cudapoa_batch->batch_id(), 0);
     EXPECT_EQ(cudapoa_batch->get_total_poas(), 0);
 }
 
 TEST_F(TestCudapoaBatch, AddPOATest)
 {
-    initialize(5, 5);
+    initialize(5);
     Group poa_group;
     poa_group.push_back(Entry{});
     std::vector<StatusType> status;
@@ -67,26 +66,9 @@ TEST_F(TestCudapoaBatch, AddPOATest)
     EXPECT_EQ(cudapoa_batch->get_total_poas(), 0);
 }
 
-TEST_F(TestCudapoaBatch, MaxPOATest)
-{
-    initialize(5, 5);
-
-    std::vector<StatusType> status;
-    for (uint16_t i = 0; i < 5; ++i)
-    {
-        Group poa_group;
-        poa_group.push_back(Entry{});
-        EXPECT_EQ(cudapoa_batch->add_poa_group(status, poa_group), StatusType::success);
-    }
-    EXPECT_EQ(cudapoa_batch->get_total_poas(), 5);
-    Group poa_group;
-    poa_group.push_back(Entry{});
-    EXPECT_EQ(cudapoa_batch->add_poa_group(status, poa_group), StatusType::exceeded_maximum_poas);
-}
-
 TEST_F(TestCudapoaBatch, MaxSeqPerPOATest)
 {
-    initialize(5, 10);
+    initialize(10);
     Group poa_group;
     std::vector<StatusType> status;
 
@@ -108,7 +90,7 @@ TEST_F(TestCudapoaBatch, MaxSeqPerPOATest)
 
 TEST_F(TestCudapoaBatch, MaxSeqSizeTest)
 {
-    initialize(5, 10);
+    initialize(10);
     Group poa_group;
     std::vector<StatusType> status;
     Entry e{};

--- a/cudapoa/tests/Test_CudapoaBatchEnd2End.cpp
+++ b/cudapoa/tests/Test_CudapoaBatchEnd2End.cpp
@@ -25,7 +25,6 @@ typedef struct
     std::string data_file;
     std::string golden_file;
     int32_t batches;
-    int32_t batch_size;
 } End2EndBatchTestParam;
 
 std::vector<End2EndBatchTestParam> getCudapoaBatchEnd2EndTestCases()
@@ -36,12 +35,10 @@ std::vector<End2EndBatchTestParam> getCudapoaBatchEnd2EndTestCases()
     test1.data_file   = std::string(CUDAPOA_BENCHMARK_DATA_DIR) + "/sample-windows.txt";
     test1.golden_file = std::string(CUDAPOA_BENCHMARK_DATA_DIR) + "/sample-golden-value.txt";
 
-    test1.batches    = 2;
-    test1.batch_size = 256;
+    test1.batches = 2;
     test_cases.push_back(test1);
 
-    test1.batches    = 4;
-    test1.batch_size = 128;
+    test1.batches = 4;
     test_cases.push_back(test1);
 
     return test_cases;
@@ -55,7 +52,7 @@ public:
     void SetUp()
     {
         param_       = GetParam();
-        multi_batch_ = std::make_unique<MultiBatch>(param_.batches, param_.batch_size, param_.data_file);
+        multi_batch_ = std::make_unique<MultiBatch>(param_.batches, param_.data_file);
     }
 
     void TearDown()

--- a/cudapoa/tests/Test_CudapoaGenerateMSA2.cpp
+++ b/cudapoa/tests/Test_CudapoaGenerateMSA2.cpp
@@ -30,8 +30,7 @@ class MSATest : public ::testing::Test
 public:
     void SetUp() {}
 
-    void initialize(uint32_t max_poas,
-                    uint32_t max_sequences_per_poa,
+    void initialize(uint32_t max_sequences_per_poa,
                     uint32_t device_id     = 0,
                     int8_t output_mask     = OutputType::msa,
                     int16_t gap_score      = -8,
@@ -44,7 +43,7 @@ public:
         cudaMemGetInfo(&free, &total);
         size_t mem_per_batch = 0.9 * free;
 
-        cudapoa_batch = claragenomics::cudapoa::create_batch(max_poas, max_sequences_per_poa, device_id, mem_per_batch, output_mask, gap_score, mismatch_score, match_score, banded_alignment);
+        cudapoa_batch = claragenomics::cudapoa::create_batch(max_sequences_per_poa, device_id, mem_per_batch, output_mask, gap_score, mismatch_score, match_score, banded_alignment);
     }
 
     std::vector<std::string> spoa_generate_multiple_sequence_alignments(std::vector<std::string> sequences,
@@ -79,7 +78,7 @@ TEST_F(MSATest, CudapoaMSA)
     std::string backbone = claragenomics::genomeutils::generate_random_genome(50, rng);
     auto sequences       = claragenomics::genomeutils::generate_random_sequences(backbone, num_sequences, rng, 10, 5, 10);
 
-    initialize(1, num_sequences + 1); //
+    initialize(num_sequences + 1); //
     Group poa_group;
     std::vector<StatusType> status;
     for (const auto& seq : sequences)


### PR DESCRIPTION
calculate max poas per batch based on available memory
and some temporary heuristics. heuristics currently needed
to decide how much device buffer to be used for input/output/temp
buffers and how much to use for scoring matrices.