### PR TITLE
[cudapoa] fix integer overflow

### DIFF
--- a/cudapoa/src/allocate_block.cpp
+++ b/cudapoa/src/allocate_block.cpp
@@ -33,8 +33,8 @@ BatchBlock::BatchBlock(int32_t device_id, size_t avail_mem, int32_t max_sequence
     max_nodes_per_window_      = banded_alignment_ ? CUDAPOA_MAX_NODES_PER_WINDOW_BANDED : CUDAPOA_MAX_NODES_PER_WINDOW;
 
     // calculate static and dynamic sizes of buffers needed per POA entry.
-    size_t host_size_fixed, device_size_fixed;
-    size_t host_size_per_poa, device_size_per_poa;
+    int64_t host_size_fixed, device_size_fixed;
+    int64_t host_size_per_poa, device_size_per_poa;
     std::tie(host_size_fixed, device_size_fixed, host_size_per_poa, device_size_per_poa) = calculate_space_per_poa();
 
     // Using 2x as a buffer.
@@ -54,8 +54,8 @@ BatchBlock::BatchBlock(int32_t device_id, size_t avail_mem, int32_t max_sequence
     max_poas_                         = (avail_mem * fraction_for_metadata) / device_size_per_poa;
 
     // Update final sizes for block based on calculated maximum POAs.
-    output_size_ = max_poas_ * static_cast<size_t>(CUDAPOA_MAX_CONSENSUS_SIZE);
-    input_size_  = max_poas_ * max_sequences_per_poa_ * static_cast<size_t>(CUDAPOA_MAX_SEQUENCE_SIZE);
+    output_size_ = max_poas_ * static_cast<int64_t>(CUDAPOA_MAX_CONSENSUS_SIZE);
+    input_size_  = max_poas_ * max_sequences_per_poa_ * static_cast<int64_t>(CUDAPOA_MAX_SEQUENCE_SIZE);
     total_h_     = max_poas_ * host_size_per_poa + host_size_fixed;
     total_d_     = avail_mem;
 
@@ -81,15 +81,15 @@ uint8_t* BatchBlock::get_block_device()
     return block_data_d_;
 }
 
-std::tuple<size_t, size_t, size_t, size_t> BatchBlock::calculate_space_per_poa()
+std::tuple<int64_t, int64_t, int64_t, int64_t> BatchBlock::calculate_space_per_poa()
 {
     const int32_t poa_count = 1;
 
-    size_t host_size_fixed = 0, device_size_fixed = 0;
-    size_t host_size_per_poa = 0, device_size_per_poa = 0;
+    int64_t host_size_fixed = 0, device_size_fixed = 0;
+    int64_t host_size_per_poa = 0, device_size_per_poa = 0;
 
-    size_t input_size_per_poa  = max_sequences_per_poa_ * CUDAPOA_MAX_SEQUENCE_SIZE * poa_count;
-    size_t output_size_per_poa = CUDAPOA_MAX_CONSENSUS_SIZE * poa_count;
+    int64_t input_size_per_poa  = max_sequences_per_poa_ * CUDAPOA_MAX_SEQUENCE_SIZE * poa_count;
+    int64_t output_size_per_poa = CUDAPOA_MAX_CONSENSUS_SIZE * poa_count;
 
     // for output - host
     host_size_fixed += sizeof(OutputDetails);                                                                                   // output_details_h_
@@ -178,16 +178,16 @@ void BatchBlock::get_output_details(OutputDetails** output_details_h_p, OutputDe
 
     // on device
     output_details_d->consensus = &block_data_d_[offset_d_];
-    offset_d_ += cudautils::align<size_t, 8>(output_size_ * sizeof(int8_t));
+    offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(int8_t));
     if (output_mask_ & OutputType::consensus)
     {
         output_details_d->coverage = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(output_size_ * sizeof(int16_t));
+        offset_d_ += cudautils::align<int64_t, 8>(output_size_ * sizeof(int16_t));
     }
     if (output_mask_ & OutputType::msa)
     {
         output_details_d->multiple_sequence_alignments = reinterpret_cast<uint8_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(output_size_ * max_sequences_per_poa_ * sizeof(uint8_t));
+        offset_d_ += cudautils::align<int64_t, 8>(output_size_ * max_sequences_per_poa_ * sizeof(uint8_t));
     }
 
     *output_details_h_p = output_details_h;
@@ -221,17 +221,17 @@ void BatchBlock::get_input_details(InputDetails** input_details_h_p, InputDetail
 
     // on device
     input_details_d->sequences = &block_data_d_[offset_d_];
-    offset_d_ += cudautils::align<size_t, 8>(input_size_ * sizeof(uint8_t));
+    offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(uint8_t));
     input_details_d->base_weights = reinterpret_cast<int8_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(input_size_ * sizeof(int8_t));
+    offset_d_ += cudautils::align<int64_t, 8>(input_size_ * sizeof(int8_t));
     input_details_d->sequence_lengths = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(uint16_t));
+    offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(uint16_t));
     input_details_d->window_details = reinterpret_cast<WindowDetails*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(max_poas_ * sizeof(WindowDetails));
+    offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * sizeof(WindowDetails));
     if (output_mask_ & OutputType::msa)
     {
         input_details_d->sequence_begin_nodes_ids = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(uint16_t));
+        offset_d_ += cudautils::align<int64_t, 8>(max_poas_ * max_sequences_per_poa_ * sizeof(uint16_t));
     }
 
     *input_details_h_p = input_details_h;
@@ -248,9 +248,9 @@ void BatchBlock::get_alignment_details(AlignmentDetails** alignment_details_d_p)
 
     // on device;
     alignment_details_d->alignment_graph = reinterpret_cast<int16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(int16_t) * max_graph_dimension_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(int16_t) * max_graph_dimension_ * max_poas_);
     alignment_details_d->alignment_read = reinterpret_cast<int16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(int16_t) * max_graph_dimension_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(int16_t) * max_graph_dimension_ * max_poas_);
 
     // rest of the available memory is assigned to scores buffer
     alignment_details_d->scorebuf_alloc_size = total_d_ - offset_d_;
@@ -268,53 +268,53 @@ void BatchBlock::get_graph_details(GraphDetails** graph_details_d_p)
 
     // on device
     graph_details_d->nodes = &block_data_d_[offset_d_];
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint8_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint8_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->node_alignments = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_ALIGNMENTS * max_poas_);
     graph_details_d->node_alignment_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->incoming_edges = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
     graph_details_d->incoming_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->outgoing_edges = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
     graph_details_d->outgoing_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->incoming_edge_weights = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
     graph_details_d->outgoing_edge_weights = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
     graph_details_d->sorted_poa = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->sorted_poa_node_map = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->sorted_poa_local_edge_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     if (output_mask_ & OutputType::consensus)
     {
         graph_details_d->consensus_scores = reinterpret_cast<int32_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(sizeof(int32_t) * max_nodes_per_window_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(int32_t) * max_nodes_per_window_ * max_poas_);
         graph_details_d->consensus_predecessors = reinterpret_cast<int16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(sizeof(int16_t) * max_nodes_per_window_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(int16_t) * max_nodes_per_window_ * max_poas_);
     }
 
     graph_details_d->node_marks = reinterpret_cast<uint8_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(int8_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(int8_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->check_aligned_nodes = reinterpret_cast<bool*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(bool) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(bool) * max_nodes_per_window_ * max_poas_);
     graph_details_d->nodes_to_visit = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     graph_details_d->node_coverage_counts = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-    offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+    offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     if (output_mask_ & OutputType::msa)
     {
         graph_details_d->outgoing_edges_coverage = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_sequences_per_poa_ * max_poas_);
         graph_details_d->outgoing_edges_coverage_count = reinterpret_cast<uint16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * CUDAPOA_MAX_NODE_EDGES * max_poas_);
         graph_details_d->node_id_to_msa_pos = reinterpret_cast<int16_t*>(&block_data_d_[offset_d_]);
-        offset_d_ += cudautils::align<size_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
+        offset_d_ += cudautils::align<int64_t, 8>(sizeof(uint16_t) * max_nodes_per_window_ * max_poas_);
     }
 
     *graph_details_d_p = graph_details_d;

--- a/cudapoa/src/allocate_block.cpp
+++ b/cudapoa/src/allocate_block.cpp
@@ -54,8 +54,8 @@ BatchBlock::BatchBlock(int32_t device_id, size_t avail_mem, int32_t max_sequence
     max_poas_                         = (avail_mem * fraction_for_metadata) / device_size_per_poa;
 
     // Update final sizes for block based on calculated maximum POAs.
-    output_size_ = max_poas_ * CUDAPOA_MAX_CONSENSUS_SIZE;
-    input_size_  = max_poas_ * max_sequences_per_poa_ * CUDAPOA_MAX_SEQUENCE_SIZE;
+    output_size_ = max_poas_ * static_cast<size_t>(CUDAPOA_MAX_CONSENSUS_SIZE);
+    input_size_  = max_poas_ * max_sequences_per_poa_ * static_cast<size_t>(CUDAPOA_MAX_SEQUENCE_SIZE);
     total_h_     = max_poas_ * host_size_per_poa + host_size_fixed;
     total_d_     = avail_mem;
 

--- a/cudapoa/src/allocate_block.hpp
+++ b/cudapoa/src/allocate_block.hpp
@@ -50,7 +50,7 @@ protected:
     // don't vary based on POA count. The latter two are host and device
     // buffer sizes that scale with number of POA entries to process. These sizes do
     // not include the scoring matrix needs for POA processing.
-    std::tuple<size_t, size_t, size_t, size_t> calculate_space_per_poa();
+    std::tuple<int64_t, int64_t, int64_t, int64_t> calculate_space_per_poa();
 
 protected:
     // Maximum POAs to process in batch.
@@ -67,18 +67,18 @@ protected:
     uint8_t* block_data_d_;
 
     // Accumulator for the memory size
-    size_t total_h_ = 0;
-    size_t total_d_ = 0;
+    int64_t total_h_ = 0;
+    int64_t total_d_ = 0;
 
     // Offset index for pointing a buffer to block memory
-    size_t offset_h_ = 0;
-    size_t offset_d_ = 0;
+    int64_t offset_h_ = 0;
+    int64_t offset_d_ = 0;
 
-    size_t input_size_;
-    size_t output_size_;
-    int32_t matrix_sequence_dimension_;
-    int32_t max_graph_dimension_;
-    uint16_t max_nodes_per_window_;
+    int64_t input_size_                = 0;
+    int64_t output_size_               = 0;
+    int32_t matrix_sequence_dimension_ = 0;
+    int32_t max_graph_dimension_       = 0;
+    int32_t max_nodes_per_window_      = 0;
     int32_t device_id_;
 
     // Bit field for output type

--- a/pyclaragenomics/test/test_cudapoa_bindings.py
+++ b/pyclaragenomics/test/test_cudapoa_bindings.py
@@ -16,9 +16,6 @@ from claragenomics.bindings.cudapoa import CudaPoaBatch
 import claragenomics.bindings.cuda as cuda
 
 
-pytestmark = pytest.mark.skip("tests are fragile, could be related to memory usage")
-
-
 @pytest.mark.gpu
 def test_cudapoa_simple_batch():
     free, total = cuda.cuda_get_mem_info(cuda.cuda_get_device())


### PR DESCRIPTION
1. Re-enable disabled cudapoa python test
2. Fix integer overflow issue in cudapoa memory management