### PR TITLE
[cudamapper] 2-bit packing of minimizer representation in the CPU implementation

### DIFF
--- a/cudamapper/src/minimizer.cpp
+++ b/cudamapper/src/minimizer.cpp
@@ -28,23 +28,25 @@ namespace claragenomics {
     Minimizer::RepresentationAndDirection Minimizer::kmer_to_representation(const std::string& basepairs, std::size_t start_element, std::size_t length) {
         std::uint64_t forward_representation = 0;
         std::uint64_t reverse_representation = 0;
-        if (length <= 2*sizeof(representation_t)) { // two basepairs per byte due to 4-bit packing
-            // TODO: Lexical ordering for now, this will change in the future
-            representation_t a = 0b000;
-            representation_t c = 0b001;
-            representation_t g = 0b010;
-            representation_t t = 0b011;
-            representation_t x = 0b100;
-            // in reverse complement base 0 goes to position length-1, 1 to length-2...
-            for (std::size_t i = start_element, position_for_reverse = 0; i < start_element + length; ++i, ++position_for_reverse) {
-                forward_representation <<= 4;
-                switch(basepairs[i]) {
-                    case 'A': forward_representation |= a; reverse_representation |= (t << 4*position_for_reverse); break;
-                    case 'C': forward_representation |= c; reverse_representation |= (g << 4*position_for_reverse); break;
-                    case 'G': forward_representation |= g; reverse_representation |= (c << 4*position_for_reverse); break;
-                    case 'T': forward_representation |= t; reverse_representation |= (a << 4*position_for_reverse); break;
-                    default : forward_representation |= x; reverse_representation |= (x << 4*position_for_reverse); break;
-                }
+
+        // Lookup table that takes four least significant bits of a basepair and returns four least significan bits of its reverse complement
+        constexpr std::uint32_t forward_to_reverse_complement[8] = { 0b0000,
+                                                                     0b0100, // A -> T (0b1 -> 0b10100)
+                                                                     0b0000,
+                                                                     0b0111, // C -> G (0b11 -> 0b111)
+                                                                     0b0001, // T -> A (0b10100 -> 0b1)
+                                                                     0b0000,
+                                                                     0b0000,
+                                                                     0b0011, // G -> C (0b111 -> 0b11)
+                                                                  };
+
+        if (length <= 4*sizeof(representation_t)) {
+            for (std::size_t i = 0; i < length; ++i) {
+                const char bp = basepairs[start_element + i];
+                //forward_representation <<= 2;
+                // first finds lexical ordering representation of basepair, then shifts it to the right position
+                forward_representation |= (0b11 & (bp >> 2 ^ bp >> 1)) << 2*(length - 1 - i);
+                reverse_representation |= (0b11 & (forward_to_reverse_complement[0b1111 & bp] >> 2 ^ forward_to_reverse_complement[0b1111 & bp] >> 1)) << 2*i;
             }
         } else {
             // TODO: throw?

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -21,7 +21,7 @@ namespace claragenomics {
     public:
         /// \brief constructor
         ///
-        /// \param representation 4-bit packed representation of a kmer
+        /// \param representation 2-bit packed representation of a kmer
         /// \param position position of the minimizer in the read
         /// \param direction in which the read was read (forward or reverse complimet)
         /// \param read_id read's id
@@ -49,7 +49,7 @@ namespace claragenomics {
         /// \return read ID
         read_id_t read_id() const override;
 
-        /// \brief converts a kmer of length length into 4-bit packed numeric representation
+        /// \brief converts a kmer of length length into 2-bit packed numeric representation
         ///
         /// Representation uses lexicographical ordering. It returns the smaller of forward and reverse complement representation
         ///

--- a/cudamapper/tests/CMakeLists.txt
+++ b/cudamapper/tests/CMakeLists.txt
@@ -17,6 +17,7 @@ set(SOURCES
     Test_CudamapperIndexGeneratorCPU.cpp
     Test_CudamapperIndexGeneratorGPU.cpp
     Test_CudamapperMatcher.cpp
+    Test_CudamapperMinimizer.cpp
     Test_PAF_generator.cpp
     ../src/bioparser_sequence.cpp)
 

--- a/cudamapper/tests/Test_CudamapperIndexCPU.cpp
+++ b/cudamapper/tests/Test_CudamapperIndexCPU.cpp
@@ -19,10 +19,10 @@ namespace claragenomics {
         // >read_0
         // GATT
 
-        // GATT = 0x2033
-        // AATC = 0x0031 <- minimizer
+        // GATT = 0b10001111
+        // AATC = 0b00001101 <- minimizer
 
-        IndexGeneratorCPU index_generator(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) +  "/one_read_one_minimizer.fasta", 4, 1);
+        IndexGeneratorCPU index_generator(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/one_read_one_minimizer.fasta", 4, 1);
         IndexCPU index(index_generator);
 
         ASSERT_EQ(index.number_of_reads(), 1);
@@ -45,15 +45,15 @@ namespace claragenomics {
 
         const std::vector<std::map<representation_t, ArrayBlock>>& read_id_and_representation_to_all_its_sketch_elements = index.read_id_and_representation_to_all_its_sketch_elements();
         ASSERT_EQ(read_id_and_representation_to_all_its_sketch_elements.size(), 1);
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0x0031), read_id_and_representation_to_all_its_sketch_elements[0].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x0031).first_element_, 0);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x0031).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0b00001101), read_id_and_representation_to_all_its_sketch_elements[0].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b00001101).first_element_, 0);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b00001101).block_size_, 1);
 
         const std::map<representation_t, ArrayBlock>& representation_to_all_its_sketch_elements = index.representation_to_all_its_sketch_elements();
         ASSERT_EQ(representation_to_all_its_sketch_elements.size(), 1);
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x0031), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x0031).first_element_, 0);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x0031).block_size_, 1);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b00001101), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b00001101).first_element_, 0);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b00001101).block_size_, 1);
     }
 
     TEST(TestCudamapperIndexCPU, TwoReadsMultipleMiniminizers) {
@@ -148,62 +148,62 @@ namespace claragenomics {
         ASSERT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].size(), 4);
         ASSERT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].size(), 3);
         // read_0 AAG(0,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0x002), read_id_and_representation_to_all_its_sketch_elements[0].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x002).first_element_, 0);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x002).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0b000010), read_id_and_representation_to_all_its_sketch_elements[0].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b000010).first_element_, 0);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b000010).block_size_, 1);
         // read_0 ATC(4,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0x031), read_id_and_representation_to_all_its_sketch_elements[0].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x031).first_element_, 4);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x031).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0b001101), read_id_and_representation_to_all_its_sketch_elements[0].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b001101).first_element_, 4);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b001101).block_size_, 1);
         // read_0 ATG(5,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0x032), read_id_and_representation_to_all_its_sketch_elements[0].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x032).first_element_, 5);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x032).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0b001110), read_id_and_representation_to_all_its_sketch_elements[0].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b001110).first_element_, 5);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b001110).block_size_, 1);
         // read_0 CAA(6,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0x100), read_id_and_representation_to_all_its_sketch_elements[0].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x100).first_element_, 6);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0x100).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[0].find(0b010000), read_id_and_representation_to_all_its_sketch_elements[0].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b010000).first_element_, 6);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[0].at(0b010000).block_size_, 1);
         // read_1 AAG(1,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0x002), read_id_and_representation_to_all_its_sketch_elements[1].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x002).first_element_, 1);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x002).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0b000010), read_id_and_representation_to_all_its_sketch_elements[1].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b000010).first_element_, 1);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b000010).block_size_, 1);
         // read_1 AGC(2,2)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0x021), read_id_and_representation_to_all_its_sketch_elements[1].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x021).first_element_, 2);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x021).block_size_, 2);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0b001001), read_id_and_representation_to_all_its_sketch_elements[1].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b001001).first_element_, 2);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b001001).block_size_, 2);
         // read_1 CTA(7,1)
-        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0x130), read_id_and_representation_to_all_its_sketch_elements[1].end());
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x130).first_element_, 7);
-        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0x130).block_size_, 1);
+        ASSERT_NE(read_id_and_representation_to_all_its_sketch_elements[1].find(0b011100), read_id_and_representation_to_all_its_sketch_elements[1].end());
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b011100).first_element_, 7);
+        EXPECT_EQ(read_id_and_representation_to_all_its_sketch_elements[1].at(0b011100).block_size_, 1);
 
         // Test representation_to_all_its_sketch_elements
         // representation_to_all_its_sketch_elements: AAG(0,2),AGC(2,2),ATC(4,1),ATG(5,1),CAA(6,1),CTA(7,1)
         const std::map<representation_t, ArrayBlock>& representation_to_all_its_sketch_elements = index.representation_to_all_its_sketch_elements();
         ASSERT_EQ(representation_to_all_its_sketch_elements.size(), 6);
         // AAG(0,2)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x002), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x002).first_element_, 0);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x002).block_size_, 2);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b000010), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b000010).first_element_, 0);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b000010).block_size_, 2);
         // AGC(2,2)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x021), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x021).first_element_, 2);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x021).block_size_, 2);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b001001), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001001).first_element_, 2);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001001).block_size_, 2);
         // ATC(4,1)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x031), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x031).first_element_, 4);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x031).block_size_, 1);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b001101), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001101).first_element_, 4);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001101).block_size_, 1);
         // ATG(5,1)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x032), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x032).first_element_, 5);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x032).block_size_, 1);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b001110), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001110).first_element_, 5);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b001110).block_size_, 1);
         // CAA(6,1)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x100), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x100).first_element_, 6);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x100).block_size_, 1);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b010000), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b010000).first_element_, 6);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b010000).block_size_, 1);
         // CTA(7,1)
-        ASSERT_NE(representation_to_all_its_sketch_elements.find(0x130), representation_to_all_its_sketch_elements.end());
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x130).first_element_, 7);
-        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0x130).block_size_, 1);
+        ASSERT_NE(representation_to_all_its_sketch_elements.find(0b011100), representation_to_all_its_sketch_elements.end());
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b011100).first_element_, 7);
+        EXPECT_EQ(representation_to_all_its_sketch_elements.at(0b011100).block_size_, 1);
     }
 
 }

--- a/cudamapper/tests/Test_CudamapperIndexGeneratorCPU.cpp
+++ b/cudamapper/tests/Test_CudamapperIndexGeneratorCPU.cpp
@@ -28,12 +28,12 @@ namespace claragenomics {
 
         const auto& representations_to_sketch_elements = index_generator.representations_to_sketch_elements();
         ASSERT_EQ(representations_to_sketch_elements.size(), 1);
-        ASSERT_NE(representations_to_sketch_elements.find(0x0031), std::end(representations_to_sketch_elements));
+        ASSERT_NE(representations_to_sketch_elements.find(0b00001101), std::end(representations_to_sketch_elements));
 
-        const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x0031)).second;
+        const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b00001101)).second;
         ASSERT_EQ(sketch_elements_for_representation.size(), 1);
         const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-        EXPECT_EQ(minimizer.representation(), 0x0031);
+        EXPECT_EQ(minimizer.representation(), 0b00001101);
         EXPECT_EQ(minimizer.position_in_read(), 0);
         EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::REVERSE);
         EXPECT_EQ(minimizer.read_id(), 0);
@@ -81,19 +81,19 @@ namespace claragenomics {
         // complete datastructure: AAG(4f0), AAG(0f1), AGC(1f1), AGC(2r1), ATC(1f0), ATG(0r0), CAA(3f0), CTA(3f1)
         // AAG (4f0), (0f1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x002), std::end(representations_to_sketch_elements)) << "AAG";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x002)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b000010), std::end(representations_to_sketch_elements)) << "AAG";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b000010)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 2) << "AAG";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x002) << "AAG (4f0)";
+                EXPECT_EQ(minimizer.representation(), 0b000010) << "AAG (4f0)";
                 EXPECT_EQ(minimizer.position_in_read(), 4) << "AAG (4f0)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "AAG (4f0)";
                 EXPECT_EQ(minimizer.read_id(), 0) << "AAG (4f0)";
             }
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[1]);
-                EXPECT_EQ(minimizer.representation(), 0x002) << "AAG (0f1)";
+                EXPECT_EQ(minimizer.representation(), 0b000010) << "AAG (0f1)";
                 EXPECT_EQ(minimizer.position_in_read(), 0) << "AAG (0f1)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "AAG (0f1)";
                 EXPECT_EQ(minimizer.read_id(), 1) << "AAG (0f1)";
@@ -101,19 +101,19 @@ namespace claragenomics {
         }
         // AGC (1f1), (2r1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x021), std::end(representations_to_sketch_elements)) << "AGC";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x021)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b001001), std::end(representations_to_sketch_elements)) << "AGC";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001001)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 2) << "AGC";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x021) << "AGC (1f1)";
+                EXPECT_EQ(minimizer.representation(), 0b001001) << "AGC (1f1)";
                 EXPECT_EQ(minimizer.position_in_read(), 1) << "AGC (1f1)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "AGC (1f1)";
                 EXPECT_EQ(minimizer.read_id(), 1) << "AGC (1f1)";
             }
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[1]);
-                EXPECT_EQ(minimizer.representation(), 0x021) << "AGC (2r1)";
+                EXPECT_EQ(minimizer.representation(), 0b001001) << "AGC (2r1)";
                 EXPECT_EQ(minimizer.position_in_read(), 2) << "AGC (r21)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::REVERSE) << "AGC (2r1)";
                 EXPECT_EQ(minimizer.read_id(), 1) << "AGC (2r1)";
@@ -121,12 +121,12 @@ namespace claragenomics {
         }
         // ATC (1f0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x031), std::end(representations_to_sketch_elements)) << "ATC";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x031)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b001101), std::end(representations_to_sketch_elements)) << "ATC";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001101)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "ATC";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x031) << "ATC (1f0)";
+                EXPECT_EQ(minimizer.representation(), 0b001101) << "ATC (1f0)";
                 EXPECT_EQ(minimizer.position_in_read(), 1) << "ATC (1f0)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "ATC (1f0)";
                 EXPECT_EQ(minimizer.read_id(), 0) << "ATC (1f0)";
@@ -134,12 +134,12 @@ namespace claragenomics {
         }
         // ATG (0r0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x032), std::end(representations_to_sketch_elements)) << "ATG";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x032)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b001110), std::end(representations_to_sketch_elements)) << "ATG";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001110)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "ATG";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x032) << "ATG (0r0)";
+                EXPECT_EQ(minimizer.representation(), 0b001110) << "ATG (0r0)";
                 EXPECT_EQ(minimizer.position_in_read(), 0) << "ATG (0r0)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::REVERSE) << "ATG (0r0)";
                 EXPECT_EQ(minimizer.read_id(), 0) << "ATG (0r0)";
@@ -147,12 +147,12 @@ namespace claragenomics {
         }
         // CAA (3f0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x100), std::end(representations_to_sketch_elements)) << "CAA";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x100)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b010000), std::end(representations_to_sketch_elements)) << "CAA";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b010000)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "CAA";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x100) << "CAA (3f0)";
+                EXPECT_EQ(minimizer.representation(), 0b010000) << "CAA (3f0)";
                 EXPECT_EQ(minimizer.position_in_read(), 3) << "CAA (3f0)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "CAA (3f0)";
                 EXPECT_EQ(minimizer.read_id(), 0) << "CAA (3f0)";
@@ -160,12 +160,12 @@ namespace claragenomics {
         }
         // CTA (3f1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0x130), std::end(representations_to_sketch_elements)) << "CTA";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0x130)).second;
+            ASSERT_NE(representations_to_sketch_elements.find(0b011100), std::end(representations_to_sketch_elements)) << "CTA";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b011100)).second;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "CTA";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
-                EXPECT_EQ(minimizer.representation(), 0x130) << "CTA (3f1)";
+                EXPECT_EQ(minimizer.representation(), 0b011100) << "CTA (3f1)";
                 EXPECT_EQ(minimizer.position_in_read(), 3) << "CTA (3f1)";
                 EXPECT_EQ(minimizer.direction(), SketchElement::DirectionOfRepresentation::FORWARD) << "CTA (3f1)";
                 EXPECT_EQ(minimizer.read_id(), 1) << "CTA (3f1)";

--- a/cudamapper/tests/Test_CudamapperIndexGeneratorGPU.cpp
+++ b/cudamapper/tests/Test_CudamapperIndexGeneratorGPU.cpp
@@ -51,7 +51,7 @@ namespace claragenomics
         }
     }
 
-/*    TEST(TestCudamapperIndexGeneratorGPU, GATT_4_1) {
+    TEST(TestCudamapperIndexGeneratorGPU, GATT_4_1) {
         // >read_0
         // GATT
         std::string filename(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/one_read_one_minimizer.fasta");
@@ -199,7 +199,7 @@ namespace claragenomics
                       representation_to_minimizers);
 
     }
-*/
+
     TEST(TestCudamapperIndexGeneratorGPU, CATCAAG_AAGCTA_3_2) {
         // >read_0
         // CATCAAG

--- a/cudamapper/tests/Test_CudamapperMinimizer.cpp
+++ b/cudamapper/tests/Test_CudamapperMinimizer.cpp
@@ -1,0 +1,99 @@
+/*
+* Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#include "gtest/gtest.h"
+#include "../src/minimizer.hpp"
+
+namespace claragenomics {
+    TEST(TestCudamapperMinimizer, GATT_4) {
+        const auto minimizer = Minimizer::kmer_to_representation(std::string("GATT"), 0, 4);
+        EXPECT_EQ(minimizer.representation_, 0b00001101);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+    }
+
+    TEST(TestCudamapperMinimizer, GATT_2) {
+        auto minimizer = Minimizer::kmer_to_representation(std::string("GATT"), 0, 2);
+        EXPECT_EQ(minimizer.representation_, 0b1000);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("GATT"), 1, 2);
+        EXPECT_EQ(minimizer.representation_, 0b0011);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("GATT"), 2, 2);
+        EXPECT_EQ(minimizer.representation_, 0b0000);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+    }
+
+    TEST(TestCudamapperMinimizer, CCCATAC_3) {
+        auto minimizer = Minimizer::kmer_to_representation(std::string("CCCATAC"), 0, 3);
+        EXPECT_EQ(minimizer.representation_, 0b010101);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CCCATAC"), 1, 3);
+        EXPECT_EQ(minimizer.representation_, 0b010100);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CCCATAC"), 2, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001110);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CCCATAC"), 3, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001100);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CCCATAC"), 4, 3);
+        EXPECT_EQ(minimizer.representation_, 0b101100);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+    }
+
+    TEST(TestCudamapperMinimizer, CATCAAG_3) {
+        auto minimizer = Minimizer::kmer_to_representation(std::string("CATCAAG"), 0, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001110);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CATCAAG"), 1, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001101);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CATCAAG"), 2, 3);
+        EXPECT_EQ(minimizer.representation_, 0b110100);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CATCAAG"), 3, 3);
+        EXPECT_EQ(minimizer.representation_, 0b010000);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("CATCAAG"), 4, 3);
+        EXPECT_EQ(minimizer.representation_, 0b000010);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+    }
+
+    TEST(TestCudamapperMinimizer, AAGCTA_3) {
+        auto minimizer = Minimizer::kmer_to_representation(std::string("AAGCTA"), 0, 3);
+        EXPECT_EQ(minimizer.representation_, 0b000010);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("AAGCTA"), 1, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001001);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("AAGCTA"), 2, 3);
+        EXPECT_EQ(minimizer.representation_, 0b001001);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::REVERSE);
+
+        minimizer = Minimizer::kmer_to_representation(std::string("AAGCTA"), 3, 3);
+        EXPECT_EQ(minimizer.representation_, 0b011100);
+        EXPECT_EQ(minimizer.direction_, SketchElement::DirectionOfRepresentation::FORWARD);
+    }
+}


### PR DESCRIPTION
`IndexGeneratorGPU` now also uses 2-bit instead of 4-bit packing of kmer representation