### PR TITLE
[cudamapper] Vector instead of map in Index<->Matcher interface

### DIFF
--- a/cudamapper/include/cudamapper/index.hpp
+++ b/cudamapper/include/cudamapper/index.hpp
@@ -21,10 +21,13 @@ namespace claragenomics {
     class Index {
     public:
 
-        /// \brief representation, pointer to section of data arrays with sketch elements with that representation and a given read_id, and a pointer to section of data arrays with sketch elements with that representation and all read_ids
+        /// RepresentationToSketchElements - representation, pointer to section of data arrays with sketch elements with that representation and a given read_id, and a pointer to section of data arrays with sketch elements with that representation and all read_ids
         struct RepresentationToSketchElements {
+            /// representation
             representation_t representation_;
+            /// pointer to all sketch elements for that representation in some read (no need to save which one)
             ArrayBlock sketch_elements_for_representation_and_read_id_;
+            /// pointer to all sketch elements with that representation in all reads
             ArrayBlock sketch_elements_for_representation_and_all_read_ids_;
         };
 

--- a/cudamapper/include/cudamapper/index.hpp
+++ b/cudamapper/include/cudamapper/index.hpp
@@ -21,6 +21,13 @@ namespace claragenomics {
     class Index {
     public:
 
+        /// \brief representation, pointer to section of data arrays with sketch elements with that representation and a given read_id, and a pointer to section of data arrays with sketch elements with that representation and all read_ids
+        struct RepresentationToSketchElements {
+            representation_t representation_;
+            ArrayBlock sketch_elements_for_representation_and_read_id_;
+            ArrayBlock sketch_elements_for_representation_and_all_read_ids_;
+        };
+
         /// \brief returns an array of starting positions of sketch elements in their reads
         /// \return an array of starting positions of sketch elements in their reads
         virtual const std::vector<position_in_read_t>& positions_in_reads() const = 0;
@@ -41,22 +48,16 @@ namespace claragenomics {
         /// \return mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
         virtual const std::vector<std::string>& read_id_to_read_name() const = 0;
 
-        /// \brief returns mapping of read id (vector) and representation (map) to section of data arrays with sketch elements with that read id and representation
-        /// \return mapping of read id (vector) and representation (map) to section of data arrays with sketch elements with that read id and representation
-        virtual const std::vector<std::map<representation_t, ArrayBlock>>& read_id_and_representation_to_all_its_sketch_elements() const = 0;
-
-        /// \brief returns mapping of representation to section of data arrays with sketch elements with that representation (and all read ids)
-        /// \return mapping of representation to section of data arrays with sketch elements with that representation (and all read ids)
-        virtual const std::map<representation_t, ArrayBlock>& representation_to_all_its_sketch_elements() const = 0;
+        /// \brief For each read_id (outer vector) returns a vector in which each element contains a representation from that read, pointer to section of data arrays with sketch elements with that representation and that read_id, and pointer to section of data arrays with skecth elements with that representation and all read_ids. There elements are sorted by representation in increasing order
+        /// \return the mapping
+        virtual const std::vector<std::vector<RepresentationToSketchElements>>& read_id_and_representation_to_sketch_elements() const = 0;
 
         /// \brief generates a mapping of (k,w)-kmer-representation to all of its occurrences for one or more sequences
-        ///
-        /// \return index
+        /// \return instance of Index
         static std::unique_ptr<Index> create_index(const IndexGenerator& index_generator);
 
-        /// \brief creates an empty index
-        ///
-        /// \return empty index
+        /// \brief creates an empty Index
+        /// \return empty instacne of Index
         static std::unique_ptr<Index> create_index();
     };
 

--- a/cudamapper/include/cudamapper/index_generator.hpp
+++ b/cudamapper/include/cudamapper/index_generator.hpp
@@ -11,7 +11,6 @@
 #pragma  once
 
 #include <cstdint>
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -26,9 +25,15 @@ namespace claragenomics {
     class IndexGenerator {
         public:
 
-        /// \brief returns a mapping of sketch element representations to all sketch elements with those representations
-        /// \return mapping of sketch element representations to all sketch elements with those representations
-        virtual const std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>>& representations_to_sketch_elements() const = 0;
+        /// \brief Representation and all sketch elements with that representation
+        struct RepresentationAndSketchElements {
+            representation_t representation_;
+            std::vector<std::unique_ptr<SketchElement>> sketch_elements_;
+        };
+
+        /// \brief Returns a vector whose each element is one representation and all sketch elements with that representation. Elements are sorted by representation in increasing order
+        /// \return the vector
+        virtual const std::vector<RepresentationAndSketchElements>& representations_and_sketch_elements() const = 0;
 
         /// \brief returns mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
         /// returns mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input

--- a/cudamapper/include/cudamapper/index_generator.hpp
+++ b/cudamapper/include/cudamapper/index_generator.hpp
@@ -25,9 +25,11 @@ namespace claragenomics {
     class IndexGenerator {
         public:
 
-        /// \brief Representation and all sketch elements with that representation
+        /// RepresentationAndSketchElements - Representation and all sketch elements with that representation
         struct RepresentationAndSketchElements {
+            /// representation
             representation_t representation_;
+            /// all sketch elements with that representation (in all reads)
             std::vector<std::unique_ptr<SketchElement>> sketch_elements_;
         };
 

--- a/cudamapper/src/index_cpu.cpp
+++ b/cudamapper/src/index_cpu.cpp
@@ -16,7 +16,7 @@ namespace claragenomics {
     IndexCPU::IndexCPU (const IndexGenerator& index_generator)
     : number_of_reads_(index_generator.number_of_reads()),
       read_id_to_read_name_(index_generator.read_id_to_read_name()),
-      read_id_and_representation_to_all_its_sketch_elements_(index_generator.number_of_reads()) {
+      read_id_and_representation_to_sketch_elements_(index_generator.number_of_reads()) {
 
         auto const& rep_to_sketch_elem = index_generator.representations_to_sketch_elements();
 
@@ -35,9 +35,7 @@ namespace claragenomics {
             const representation_t current_rep = key_value_for_current_rep.first;
             const auto& sketch_elems_for_current_rep = key_value_for_current_rep.second;
             // all sketch elements with the current representation are going to be added to this section of the data arrays
-            ArrayBlock array_block_for_current_rep = ArrayBlock{positions_in_reads_.size(), static_cast<std::uint32_t>(sketch_elems_for_current_rep.size())};
-            representation_to_all_its_sketch_elements_.emplace(std::make_pair(current_rep, array_block_for_current_rep));
-            // add all sketch elements
+            ArrayBlock array_block_for_current_rep_and_all_read_ids = ArrayBlock{positions_in_reads_.size(), static_cast<std::uint32_t>(sketch_elems_for_current_rep.size())};
             read_id_t current_read = std::numeric_limits<read_id_t>::max();
             for (const auto& sketch_elem_ptr : sketch_elems_for_current_rep) {
                 const read_id_t read_of_current_sketch_elem = sketch_elem_ptr->read_id();
@@ -45,11 +43,10 @@ namespace claragenomics {
                 if (read_of_current_sketch_elem != current_read) {
                     // if new read_id add new block for it
                     current_read = read_of_current_sketch_elem;
-                    read_id_and_representation_to_all_its_sketch_elements_[current_read].emplace(std::make_pair(current_rep, ArrayBlock{positions_in_reads_.size(), 1}));
+                    read_id_and_representation_to_sketch_elements_[read_of_current_sketch_elem].push_back(RepresentationToSketchElements{current_rep, {positions_in_reads_.size(), 1}, array_block_for_current_rep_and_all_read_ids});
                 } else {
                     // if a block for that read_id alreay exists just increase the counter for the number of elements with that representation and read_id
-                    // TODO: we're going through the map for each sketch element
-                    ++read_id_and_representation_to_all_its_sketch_elements_[current_read][current_rep].block_size_;
+                    ++read_id_and_representation_to_sketch_elements_[read_of_current_sketch_elem].back().sketch_elements_for_representation_and_read_id_.block_size_;
                 }
                 // add sketch element to data arrays
                 positions_in_reads_.emplace_back(sketch_elem_ptr->position_in_read());
@@ -57,7 +54,6 @@ namespace claragenomics {
                 directions_of_reads_.emplace_back(sketch_elem_ptr->direction());
             }
         }
-
     }
 
     IndexCPU::IndexCPU()
@@ -74,8 +70,5 @@ namespace claragenomics {
 
     const std::vector<std::string>& IndexCPU::read_id_to_read_name() const { return read_id_to_read_name_; }
 
-    const std::vector<std::map<representation_t, ArrayBlock>>& IndexCPU::read_id_and_representation_to_all_its_sketch_elements() const { return read_id_and_representation_to_all_its_sketch_elements_; }
-
-    const std::map<representation_t, ArrayBlock>& IndexCPU::representation_to_all_its_sketch_elements() const { return representation_to_all_its_sketch_elements_; }
-
+    const std::vector<std::vector<Index::RepresentationToSketchElements>>& IndexCPU::read_id_and_representation_to_sketch_elements() const { return read_id_and_representation_to_sketch_elements_; }
 }

--- a/cudamapper/src/index_cpu.cpp
+++ b/cudamapper/src/index_cpu.cpp
@@ -18,12 +18,12 @@ namespace claragenomics {
       read_id_to_read_name_(index_generator.read_id_to_read_name()),
       read_id_and_representation_to_sketch_elements_(index_generator.number_of_reads()) {
 
-        auto const& rep_to_sketch_elem = index_generator.representations_to_sketch_elements();
+        auto const& rep_to_sketch_elem = index_generator.representations_and_sketch_elements();
 
         // determine the overall number of sketch elements and preallocate data arrays
         std::uint64_t total_sketch_elems = 0;
         for (const auto& sketch_elems_for_one_rep : rep_to_sketch_elem) {
-            total_sketch_elems += sketch_elems_for_one_rep.second.size();
+            total_sketch_elems += sketch_elems_for_one_rep.sketch_elements_.size();
         }
 
         positions_in_reads_.reserve(total_sketch_elems);
@@ -31,9 +31,9 @@ namespace claragenomics {
         directions_of_reads_.reserve(total_sketch_elems);
 
         // go through representations one by one
-        for (const auto& key_value_for_current_rep : rep_to_sketch_elem) {
-            const representation_t current_rep = key_value_for_current_rep.first;
-            const auto& sketch_elems_for_current_rep = key_value_for_current_rep.second;
+        for (const auto& sketch_elems_for_one_rep : rep_to_sketch_elem) {
+            const representation_t current_rep = sketch_elems_for_one_rep.representation_;
+            const auto& sketch_elems_for_current_rep = sketch_elems_for_one_rep.sketch_elements_;
             // all sketch elements with the current representation are going to be added to this section of the data arrays
             ArrayBlock array_block_for_current_rep_and_all_read_ids = ArrayBlock{positions_in_reads_.size(), static_cast<std::uint32_t>(sketch_elems_for_current_rep.size())};
             read_id_t current_read = std::numeric_limits<read_id_t>::max();

--- a/cudamapper/src/index_cpu.hpp
+++ b/cudamapper/src/index_cpu.hpp
@@ -23,14 +23,12 @@ namespace claragenomics {
     ///
     /// Class contains three separate data arrays: read_ids, positions_in_reads and directions_of_reads.
     /// Elements of these three arrays with the same index represent one sketch element
-    /// (read it belongs to, position in that read of the first basepair of sketch element and whether it is forward or reverse complement representation).
+    /// (read_id of the read it belongs to, position in that read of the first basepair of sketch element and whether it is forward or reverse complement representation).
     /// Representation itself is not saved as it is not necessary for matching phase. It can be retrieved from the original data if needed.
     ///
-    /// representation_to_all_its_sketch_elements() returns a hash map that maps a sketch element representation to section of data arrays with all sketch elements with that representation
+    /// Elements of data arrays are grouped by sketch element representation and within those groups by read_id. Both representations and read_ids within representations are sorted in ascending order
     ///
-    /// read_id_and_representation_to_all_its_sketch_elements() similarly maps read id and sketch element representation to srction of data arrays with all sketch elements with that read id representation
-    ///
-    /// Elements of data arrays are grouped by sketch element representation and within those groups by read id. Both representations and read ids within representations are sorted in ascending order
+    /// read_id_and_representation_to_sketch_elements() for each read_id (outer vector) returns a vector in which each element contains a representation from that read, pointer to section of data arrays with sketch elements with that representation and that read_id, and pointer to section of data arrays with skecth elements with that representation and all read_ids. There elements are sorted by representation in increasing order
     class IndexCPU : public Index {
     public:
 
@@ -62,13 +60,9 @@ namespace claragenomics {
         /// \return mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
         const std::vector<std::string>& read_id_to_read_name() const override;
 
-        /// \brief returns mapping of read id (vector) and representation (map) to section of data arrays with sketch elements with that read id and representation
-        /// \return mapping of read id (vector) and representation (map) to section of data arrays with sketch elements with that read id and representation
-        const std::vector<std::map<representation_t, ArrayBlock>>& read_id_and_representation_to_all_its_sketch_elements() const override;
-
-        /// \brief returns mapping of representation to section of data arrays with sketch elements with that representation (and all read ids)
-        /// \return mapping of representation to section of data arrays with sketch elements with that representation (and all read ids)
-        const std::map<representation_t, ArrayBlock>& representation_to_all_its_sketch_elements() const override;
+        /// \brief For each read_id (outer vector) returns a vector in which each element contains a representation from that read, pointer to section of data arrays with sketch elements with that representation and that read_id, and pointer to section of data arrays with skecth elements with that representation and all read_ids. There elements are sorted by representation in increasing order
+        /// \return the mapping
+        const std::vector<std::vector<Index::RepresentationToSketchElements>>& read_id_and_representation_to_sketch_elements() const override;
 
     private:
 
@@ -80,9 +74,7 @@ namespace claragenomics {
 
         const std::vector<std::string> read_id_to_read_name_;
 
-        std::vector<std::map<representation_t, ArrayBlock>> read_id_and_representation_to_all_its_sketch_elements_;
-
-        std::map<representation_t, ArrayBlock> representation_to_all_its_sketch_elements_;
+        std::vector<std::vector<RepresentationToSketchElements>> read_id_and_representation_to_sketch_elements_;
     };
         
 

--- a/cudamapper/src/index_cpu.hpp
+++ b/cudamapper/src/index_cpu.hpp
@@ -76,6 +76,4 @@ namespace claragenomics {
 
         std::vector<std::vector<RepresentationToSketchElements>> read_id_and_representation_to_sketch_elements_;
     };
-        
-
 }

--- a/cudamapper/src/index_generator_cpu.cpp
+++ b/cudamapper/src/index_generator_cpu.cpp
@@ -22,7 +22,7 @@
 namespace claragenomics {
 
     IndexGeneratorCPU::IndexGeneratorCPU(const std::string& query_filename, std::uint64_t minimizer_size, std::uint64_t window_size)
-    : minimizer_size_(minimizer_size), window_size_(window_size), index_()
+    : minimizer_size_(minimizer_size), window_size_(window_size), temporary_index_(), index_()
     {
         generate_index(query_filename);
     }
@@ -31,7 +31,7 @@ namespace claragenomics {
 
     std::uint64_t IndexGeneratorCPU::window_size() const { return window_size_; }
 
-    const std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>>& IndexGeneratorCPU::representations_to_sketch_elements() const { return index_; };
+    const std::vector<IndexGenerator::RepresentationAndSketchElements>& IndexGeneratorCPU::representations_and_sketch_elements() const { return index_; };
 
     const std::vector<std::string>& IndexGeneratorCPU::read_id_to_read_name() const { return read_id_to_read_name_; };
 
@@ -64,6 +64,21 @@ namespace claragenomics {
             add_read_to_index(*fasta_objects[read_id], read_id);
         }
         number_of_reads_ = fasta_objects.size();
+
+        // index is first constructed in a map and here it is transformed into a vector
+        // TODO: This a workaround/quick_and_diry_hack with bad performance. Rewrite is we decide to keep IndexGeneratorCPU implementation
+        for (auto const& sketch_elements_for_one_representation : temporary_index_) {
+            representation_t representation = sketch_elements_for_one_representation.first;
+            index_.push_back(RepresentationAndSketchElements{representation, {}});
+            for (auto const& one_minimizer : sketch_elements_for_one_representation.second) {
+                index_.back().sketch_elements_.push_back(std::make_unique<Minimizer>(one_minimizer->representation(),
+                                                                                     one_minimizer->position_in_read(),
+                                                                                     one_minimizer->direction(),
+                                                                                     one_minimizer->read_id()
+                                                                                    )
+                                                        );
+            }
+        }
     }
 
     void IndexGeneratorCPU::add_read_to_index(const Sequence& read, const read_id_t read_id) {
@@ -99,7 +114,7 @@ namespace claragenomics {
         }
         // add all position of the minimizer of the first window
         for (const std::pair<position_in_read_t, Minimizer::DirectionOfRepresentation>& pos : minimizer_pos) {
-            index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, pos.first, pos.second, read_id));
+            temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, pos.first, pos.second, read_id));
         }
         first_window_minimizer_representation = current_minimizer_representation;
 
@@ -125,28 +140,28 @@ namespace claragenomics {
                         }
                     }
                     for (const std::pair<position_in_read_t, Minimizer::DirectionOfRepresentation>& pos : minimizer_pos) {
-                        index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, pos.first, pos.second, read_id));
+                        temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, pos.first, pos.second, read_id));
                     }
                 } else { // there are other kmers with that value, proceed as if the oldest element was not not the smallest one
                     if (kmers_in_window.back().representation_ == current_minimizer_representation) {
                         minimizer_pos.emplace_back(window_num + minimizer_size_ - 1, kmers_in_window.back().direction_);
-                        index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
+                        temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
                     } else if (kmers_in_window.back().representation_ < current_minimizer_representation) {
                         minimizer_pos.clear();
                         current_minimizer_representation = kmers_in_window.back().representation_;
                         minimizer_pos.emplace_back(window_num + minimizer_size_ - 1, kmers_in_window.back().direction_);
-                        index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
+                        temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
                     }
                 }
             } else {  // oldest kmer was not the minimizer
                 if (kmers_in_window.back().representation_ == current_minimizer_representation) {
                     minimizer_pos.emplace_back(window_num + minimizer_size_ - 1, kmers_in_window.back().direction_);
-                    index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
+                    temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
                 } else if (kmers_in_window.back().representation_ < current_minimizer_representation) {
                     minimizer_pos.clear();
                     current_minimizer_representation = kmers_in_window.back().representation_;
                     minimizer_pos.emplace_back(window_num + minimizer_size_ - 1, kmers_in_window.back().direction_);
-                    index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
+                    temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, window_num + window_size_ - 1, kmers_in_window.back().direction_, read_id));
                 }
             }
         }
@@ -181,7 +196,7 @@ namespace claragenomics {
                 if (new_kmer.representation_ < current_minimizer_representation) {
                     current_minimizer_representation = new_kmer.representation_;
                 }
-                index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, current_window_size-1, new_kmer.direction_, read_id));
+                temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, current_window_size-1, new_kmer.direction_, read_id));
             }
         }
 
@@ -197,7 +212,7 @@ namespace claragenomics {
                 if (new_kmer.representation_ < current_minimizer_representation) {
                     current_minimizer_representation = new_kmer.representation_;
                 }
-                index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, kmer_begin_position, new_kmer.direction_, read_id));
+                temporary_index_[current_minimizer_representation].emplace_back(std::make_unique<Minimizer>(current_minimizer_representation, kmer_begin_position, new_kmer.direction_, read_id));
             }
         }
     }

--- a/cudamapper/src/index_generator_cpu.hpp
+++ b/cudamapper/src/index_generator_cpu.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
 #include "cudamapper/index_generator.hpp"
 #include "cudamapper/sequence.hpp"
 #include "cudamapper/types.hpp"
@@ -35,9 +36,9 @@ namespace claragenomics {
         /// \return window size
         std::uint64_t window_size() const;
 
-        /// \brief returns a mapping of minimizer representations to all minimizers with those representations
-        /// \return mapping of minimzer representations to all minimizers with those representations
-        const std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>>& representations_to_sketch_elements() const override;
+        /// \brief Returns a vector whose each element is one representation and all sketch elements with that representation. Elements are sorted by representation in increasing order
+        /// \return the vector
+        virtual const std::vector<RepresentationAndSketchElements>& representations_and_sketch_elements() const override;
 
         /// \brief returns mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
         /// \return mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
@@ -76,7 +77,10 @@ namespace claragenomics {
         std::uint64_t minimizer_size_;
         std::uint64_t window_size_;
         std::uint64_t number_of_reads_;
-        std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>> index_;
+        // index is first constructed in a map and than transformed into a vector
+        // TODO: This a workaround with bad performance. Rewrite is we decide to keep IndexGeneratorCPU implementation
+        std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>> temporary_index_;
+        std::vector<RepresentationAndSketchElements> index_;
         std::vector<std::string> read_id_to_read_name_;
     };
 }

--- a/cudamapper/src/index_generator_gpu.hpp
+++ b/cudamapper/src/index_generator_gpu.hpp
@@ -35,9 +35,9 @@ namespace claragenomics {
         /// \return window size
         std::uint64_t window_size() const;
 
-        /// \brief returns a mapping of minimizer representations to all minimizers with those representations
-        /// \return mapping of minimzer representations to all minimizers with those representations
-        const std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>>& representations_to_sketch_elements() const override;
+        /// \brief Returns a vector whose each element is one representation and all sketch elements with that representation. Elements are sorted by representation in increasing order
+        /// \return the vector
+        const std::vector<RepresentationAndSketchElements>& representations_and_sketch_elements() const override;
 
         /// \brief returns mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
         /// \return mapping of internal read id that goes from 0 to number_of_reads-1 to actual read name from the input
@@ -55,7 +55,7 @@ namespace claragenomics {
         std::uint64_t minimizer_size_;
         std::uint64_t window_size_;
         std::uint64_t number_of_reads_;
-        std::map<representation_t, std::vector<std::unique_ptr<SketchElement>>> index_;
+        std::vector<RepresentationAndSketchElements> index_;
         std::vector<std::string> read_id_to_read_name_;
     };
 }

--- a/cudamapper/tests/Test_CudamapperIndexGeneratorCPU.cpp
+++ b/cudamapper/tests/Test_CudamapperIndexGeneratorCPU.cpp
@@ -26,11 +26,11 @@ namespace claragenomics {
         ASSERT_EQ(index_generator.read_id_to_read_name().size(), 1);
         EXPECT_EQ(index_generator.read_id_to_read_name()[0], std::string("read_0"));
 
-        const auto& representations_to_sketch_elements = index_generator.representations_to_sketch_elements();
-        ASSERT_EQ(representations_to_sketch_elements.size(), 1);
-        ASSERT_NE(representations_to_sketch_elements.find(0b00001101), std::end(representations_to_sketch_elements));
+        const auto& representations_and_sketch_elements = index_generator.representations_and_sketch_elements();
+        ASSERT_EQ(representations_and_sketch_elements.size(), 1);
+        ASSERT_EQ(representations_and_sketch_elements[0].representation_, 0b00001101);
 
-        const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b00001101)).second;
+        const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[0].sketch_elements_;
         ASSERT_EQ(sketch_elements_for_representation.size(), 1);
         const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
         EXPECT_EQ(minimizer.representation(), 0b00001101);
@@ -75,14 +75,14 @@ namespace claragenomics {
         EXPECT_EQ(index_generator.read_id_to_read_name()[0], std::string("read_0"));
         EXPECT_EQ(index_generator.read_id_to_read_name()[1], std::string("read_1"));
 
-        const auto& representations_to_sketch_elements = index_generator.representations_to_sketch_elements();
-        ASSERT_EQ(representations_to_sketch_elements.size(), 6);
+        const auto& representations_and_sketch_elements = index_generator.representations_and_sketch_elements();
+        ASSERT_EQ(representations_and_sketch_elements.size(), 6);
 
         // complete datastructure: AAG(4f0), AAG(0f1), AGC(1f1), AGC(2r1), ATC(1f0), ATG(0r0), CAA(3f0), CTA(3f1)
         // AAG (4f0), (0f1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b000010), std::end(representations_to_sketch_elements)) << "AAG";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b000010)).second;
+            ASSERT_EQ(representations_and_sketch_elements[0].representation_, 0b000010) << "AAG";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[0].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 2) << "AAG";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -101,8 +101,8 @@ namespace claragenomics {
         }
         // AGC (1f1), (2r1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b001001), std::end(representations_to_sketch_elements)) << "AGC";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001001)).second;
+            ASSERT_EQ(representations_and_sketch_elements[1].representation_, 0b001001) << "AGC";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[1].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 2) << "AGC";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -121,8 +121,8 @@ namespace claragenomics {
         }
         // ATC (1f0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b001101), std::end(representations_to_sketch_elements)) << "ATC";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001101)).second;
+            ASSERT_EQ(representations_and_sketch_elements[2].representation_, 0b001101) << "ATC";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[2].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "ATC";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -134,8 +134,8 @@ namespace claragenomics {
         }
         // ATG (0r0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b001110), std::end(representations_to_sketch_elements)) << "ATG";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b001110)).second;
+            ASSERT_EQ(representations_and_sketch_elements[3].representation_, 0b001110) << "ATG";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[3].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "ATG";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -147,8 +147,8 @@ namespace claragenomics {
         }
         // CAA (3f0)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b010000), std::end(representations_to_sketch_elements)) << "CAA";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b010000)).second;
+            ASSERT_EQ(representations_and_sketch_elements[4].representation_, 0b010000) << "CAA";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[4].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "CAA";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -160,8 +160,8 @@ namespace claragenomics {
         }
         // CTA (3f1)
         {
-            ASSERT_NE(representations_to_sketch_elements.find(0b011100), std::end(representations_to_sketch_elements)) << "CTA";
-            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = (*representations_to_sketch_elements.find(0b011100)).second;
+            ASSERT_EQ(representations_and_sketch_elements[5].representation_, 0b011100) << "CTA";
+            const std::vector<std::unique_ptr<SketchElement>>& sketch_elements_for_representation = representations_and_sketch_elements[5].sketch_elements_;
             ASSERT_EQ(sketch_elements_for_representation.size(), 1) << "CTA";
             {
                 const Minimizer& minimizer = static_cast<const Minimizer&>(*sketch_elements_for_representation[0]);
@@ -172,5 +172,4 @@ namespace claragenomics {
             }
         }
     }
-
 }

--- a/cudamapper/tests/Test_CudamapperIndexGeneratorGPU.cpp
+++ b/cudamapper/tests/Test_CudamapperIndexGeneratorGPU.cpp
@@ -9,6 +9,7 @@
 */
 
 #include "gtest/gtest.h"
+#include <utility>
 #include "cudamapper_file_location.hpp"
 #include "../src/index_generator_gpu.hpp"
 
@@ -20,7 +21,7 @@ namespace claragenomics
                        const std::uint64_t window_size,
                        const std::uint64_t number_of_reads,
                        const std::vector<std::string>& read_id_to_read_name,
-                       const std::map<representation_t, std::vector<Minimizer>>& representation_to_minimizers) {
+                       const std::vector<std::pair<representation_t, std::vector<Minimizer>>>& representation_and_minimizers) {
         IndexGeneratorGPU index_generator(filename, minimizer_size, window_size);
 
         EXPECT_EQ(index_generator.minimizer_size(), minimizer_size);
@@ -32,21 +33,22 @@ namespace claragenomics
             EXPECT_EQ(index_generator.read_id_to_read_name()[read_id], read_id_to_read_name[read_id]) << "read_id: " << read_id;
         }
 
-        const auto& representation_to_sketch_elements = index_generator.representations_to_sketch_elements();
-        ASSERT_EQ(representation_to_sketch_elements.size(), representation_to_minimizers.size());
-        for(const auto& one_representation : representation_to_minimizers) {
-            const representation_t current_representation = one_representation.first;
-            const std::vector<Minimizer>& current_minimizers_expected = one_representation.second;
-            ASSERT_NE(representation_to_sketch_elements.find(current_representation), std::end(representation_to_sketch_elements)) << "representation: " << current_representation;
+        const std::vector<IndexGenerator::RepresentationAndSketchElements>& representations_and_sketch_elements = index_generator.representations_and_sketch_elements();
+        ASSERT_EQ(representations_and_sketch_elements.size(), representation_and_minimizers.size());
+        for(std::size_t i = 0; i < representation_and_minimizers.size(); ++i) {
+            const representation_t representation_expected = representation_and_minimizers[i].first;
+            const representation_t representation_generated = representations_and_sketch_elements[i].representation_;
+            ASSERT_EQ(representation_expected, representation_generated) << "representation: " << representation_expected;
 
-            const std::vector<std::unique_ptr<SketchElement>>& current_minimizers_generated = (*representation_to_sketch_elements.find(current_representation)).second;
-            ASSERT_EQ(current_minimizers_generated.size(), current_minimizers_expected.size()) << "representation: " << current_representation;
+            const std::vector<Minimizer>& current_minimizers_expected = representation_and_minimizers[i].second;
+            const std::vector<std::unique_ptr<SketchElement>>& current_minimizers_generated = representations_and_sketch_elements[i].sketch_elements_;
+            ASSERT_EQ(current_minimizers_expected.size(), current_minimizers_generated.size()) << "representation: " << representation_expected;
 
-            for (std::size_t i = 0; i < current_minimizers_expected.size(); ++i) {
-                EXPECT_EQ(current_minimizers_generated[i]->representation(), current_minimizers_expected[i].representation()) << "representation: " << current_representation << ", index: " << i;
-                EXPECT_EQ(current_minimizers_generated[i]->position_in_read(), current_minimizers_expected[i].position_in_read()) << "representation: " << current_representation << ", index: " << i;
-                EXPECT_EQ(current_minimizers_generated[i]->direction(), current_minimizers_expected[i].direction()) << "representation: " << current_representation << ", index: " << i;
-                EXPECT_EQ(current_minimizers_generated[i]->read_id(), current_minimizers_expected[i].read_id()) << "representation: " << current_representation << ", index: " << i;
+            for (std::size_t j = 0; j < current_minimizers_expected.size(); ++j) {
+                EXPECT_EQ(current_minimizers_generated[j]->representation(), current_minimizers_expected[j].representation()) << "representation: " << representation_expected << ", index: " << j;
+                EXPECT_EQ(current_minimizers_generated[j]->position_in_read(), current_minimizers_expected[j].position_in_read()) << "representation: " << representation_expected << ", index: " << j;
+                EXPECT_EQ(current_minimizers_generated[j]->direction(), current_minimizers_expected[j].direction()) << "representation: " << representation_expected << ", index: " << j;
+                EXPECT_EQ(current_minimizers_generated[j]->read_id(), current_minimizers_expected[j].read_id()) << "representation: " << representation_expected << ", index: " << j;
             }
         }
     }
@@ -62,18 +64,16 @@ namespace claragenomics
         std::vector<std::string> read_id_to_read_name;
         read_id_to_read_name.push_back("read_0");
 
-        std::map<representation_t, std::vector<Minimizer>> representation_to_minimizers;
-        { // 0b1101
-            std::vector<Minimizer> minimizers{{0b1101, 0, SketchElement::DirectionOfRepresentation::REVERSE, 0}};
-            representation_to_minimizers[0b1101] = minimizers;
-        }
+        std::vector<std::pair<representation_t, std::vector<Minimizer>>> representation_and_minimizers;
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b1101, {}});
+        representation_and_minimizers.back().second.push_back({0b1101, 0, SketchElement::DirectionOfRepresentation::REVERSE, 0});
 
         test_function(filename,
                       minimizer_size,
                       window_size,
                       number_of_reads,
                       read_id_to_read_name,
-                      representation_to_minimizers);
+                      representation_and_minimizers);
     }
 
     TEST(TestCudamapperIndexGeneratorGPU, GATT_2_3) {
@@ -87,26 +87,20 @@ namespace claragenomics
         std::vector<std::string> read_id_to_read_name;
         read_id_to_read_name.push_back("read_0");
 
-        std::map<representation_t, std::vector<Minimizer>> representation_to_minimizers;
-        { // 0b1000
-            std::vector<Minimizer> minimizers{{0b1000, 0, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b1000] = minimizers;
-        }
-        { // 0b0011
-            std::vector<Minimizer> minimizers{{0b0011, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b0011] = minimizers;
-        }
-        { // 0b0000
-            std::vector<Minimizer> minimizers{{0b0000, 2, SketchElement::DirectionOfRepresentation::REVERSE, 0}};
-            representation_to_minimizers[0b0000] = minimizers;
-        }
+        std::vector<std::pair<representation_t, std::vector<Minimizer>>> representation_and_minimizers;
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b0000, {}});
+        representation_and_minimizers.back().second.push_back({0b0000, 2, SketchElement::DirectionOfRepresentation::REVERSE, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b0011, {}});
+        representation_and_minimizers.back().second.push_back({0b0011, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b1000, {}});
+        representation_and_minimizers.back().second.push_back({0b1000, 0, SketchElement::DirectionOfRepresentation::FORWARD, 0});
 
         test_function(filename,
                       minimizer_size,
                       window_size,
                       number_of_reads,
                       read_id_to_read_name,
-                      representation_to_minimizers);
+                      representation_and_minimizers);
     }
 
     TEST(TestCudamapperIndexGeneratorGPU, CCCATACC_2_8) {
@@ -121,14 +115,14 @@ namespace claragenomics
 
         std::vector<std::string> read_id_to_read_name;
 
-        std::map<representation_t, std::vector<Minimizer>> representation_to_minimizers;
+        std::vector<std::pair<representation_t, std::vector<Minimizer>>> representation_and_minimizers;
 
         test_function(filename,
                       minimizer_size,
                       window_size,
                       number_of_reads,
                       read_id_to_read_name,
-                      representation_to_minimizers);
+                      representation_and_minimizers);
     }
 
     TEST(TestCudamapperIndexGeneratorGPU, CCCATAC_3_5) {
@@ -159,7 +153,8 @@ namespace claragenomics
         // TACC  : 011 5 F
         // ACC   : 011 5 F
 
-        // all minimizers: (111,0,F)m (110,1,F), (032,2,R), (030,3,F), (011,5,F)
+        // all minimizers: (111,0,F), (110,1,F), (032,2,R), (030,3,F), (011,5,F)
+        // all minimizers sorted: (011,5,F), (030,3,F), (032,2,R), (110,1,F), (111,0,F)
 
         std::string filename(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/cccatacc.fasta");
         std::uint64_t minimizer_size = 3;
@@ -169,34 +164,24 @@ namespace claragenomics
         std::vector<std::string> read_id_to_read_name;
         read_id_to_read_name.push_back("read_0");
 
-        std::map<representation_t, std::vector<Minimizer>> representation_to_minimizers;
-        { // 111
-            std::vector<Minimizer> minimizers{{0b010101, 0, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b010101] = minimizers;
-        }
-        { // 110
-            std::vector<Minimizer> minimizers{{0b010100, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b010100] = minimizers;
-        }
-        { // 032
-            std::vector<Minimizer> minimizers{{0b001110, 2, SketchElement::DirectionOfRepresentation::REVERSE, 0}};
-            representation_to_minimizers[0b001110] = minimizers;
-        }
-        { // 030
-            std::vector<Minimizer> minimizers{{0b001100, 3, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b001100] = minimizers;
-        }
-        { // 011
-            std::vector<Minimizer> minimizers{{0b000101, 5, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b000101] = minimizers;
-        }
+        std::vector<std::pair<representation_t, std::vector<Minimizer>>> representation_and_minimizers;
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b000101, {}});
+        representation_and_minimizers.back().second.push_back({0b000101, 5, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b001100, {}});
+        representation_and_minimizers.back().second.push_back({0b001100, 3, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b001110, {}});
+        representation_and_minimizers.back().second.push_back({0b001110, 2, SketchElement::DirectionOfRepresentation::REVERSE, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b010100, {}});
+        representation_and_minimizers.back().second.push_back({0b010100, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b010101, {}});
+        representation_and_minimizers.back().second.push_back({0b010101, 0, SketchElement::DirectionOfRepresentation::FORWARD, 0});
 
         test_function(filename,
                       minimizer_size,
                       window_size,
                       number_of_reads,
                       read_id_to_read_name,
-                      representation_to_minimizers);
+                      representation_and_minimizers);
 
     }
 
@@ -247,6 +232,7 @@ namespace claragenomics
         // CTA: 130 3 F 1
 
         // all minimizers: (032,0,R,0), (031,1,F,0), (100,3,F,0), (002,4,F,0), (002,0,F,1), (021,2,R,1), (130,3,F,1)
+        // all minimizers sorted: (002,4,F,0), (002,0,F,1), (021,2,R,1), (031,1,F,0), (032,0,R,0), (100,3,F,0), (130,3,F,1)
 
         std::string filename(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/two_reads_multiple_minimizers.fasta");
         std::uint64_t minimizer_size = 3;
@@ -257,39 +243,30 @@ namespace claragenomics
         read_id_to_read_name.push_back("read_0");
         read_id_to_read_name.push_back("read_1");
 
-        std::map<representation_t, std::vector<Minimizer>> representation_to_minimizers;
-        { // 032
-            std::vector<Minimizer> minimizers{{0b001110, 0, SketchElement::DirectionOfRepresentation::REVERSE, 0}};
-            representation_to_minimizers[0b001110] = minimizers;
-        }
-        { // 031
-            std::vector<Minimizer> minimizers{{0b001101, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b001101] = minimizers;
-        }
-        { // 100
-            std::vector<Minimizer> minimizers{{0b010000, 3, SketchElement::DirectionOfRepresentation::FORWARD, 0}};
-            representation_to_minimizers[0b010000] = minimizers;
-        }
-        { // 002
-            std::vector<Minimizer> minimizers{{0b000010, 4, SketchElement::DirectionOfRepresentation::FORWARD, 0},
-                                              {0b000010, 0, SketchElement::DirectionOfRepresentation::FORWARD, 1}};
-            representation_to_minimizers[0b000010] = minimizers;
-        }
-        { // 021
-            std::vector<Minimizer> minimizers{{0b001001, 2, SketchElement::DirectionOfRepresentation::REVERSE, 1}};
-            representation_to_minimizers[0b001001] = minimizers;
-        }
-        { // 130
-            std::vector<Minimizer> minimizers{{0b011100, 3, SketchElement::DirectionOfRepresentation::FORWARD, 1}};
-            representation_to_minimizers[0b011100] = minimizers;
-        }
+        std::vector<std::pair<representation_t, std::vector<Minimizer>>> representation_and_minimizers;
+
+
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b000010, {}});
+        representation_and_minimizers.back().second.push_back({0b000010, 4, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.back().second.push_back({0b000010, 0, SketchElement::DirectionOfRepresentation::FORWARD, 1});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b001001, {}});
+        representation_and_minimizers.back().second.push_back({0b001001, 2, SketchElement::DirectionOfRepresentation::REVERSE, 1});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b001101, {}});
+        representation_and_minimizers.back().second.push_back({0b001101, 1, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b001110, {}});
+        representation_and_minimizers.back().second.push_back({0b001110, 0, SketchElement::DirectionOfRepresentation::REVERSE, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b010000, {}});
+        representation_and_minimizers.back().second.push_back({0b010000, 3, SketchElement::DirectionOfRepresentation::FORWARD, 0});
+        representation_and_minimizers.push_back(std::pair<representation_t, std::vector<Minimizer>>{0b011100, {}});
+        representation_and_minimizers.back().second.push_back({0b011100, 3, SketchElement::DirectionOfRepresentation::FORWARD, 1});
+
 
         test_function(filename,
                       minimizer_size,
                       window_size,
                       number_of_reads,
                       read_id_to_read_name,
-                      representation_to_minimizers);
+                      representation_and_minimizers);
 
     }
 

--- a/cudamapper/tests/Test_CudamapperMatcher.cpp
+++ b/cudamapper/tests/Test_CudamapperMatcher.cpp
@@ -78,8 +78,7 @@ namespace claragenomics {
         const std::vector<SketchElement::DirectionOfRepresentation>& directions_of_reads() const override { return directions_of_reads_; }
         std::uint64_t number_of_reads() const override { return number_of_reads_; }
         const std::vector<std::string>& read_id_to_read_name() const override { return read_id_to_read_name_; }
-        const std::vector<std::map<representation_t, ArrayBlock>>& read_id_and_representation_to_all_its_sketch_elements() const override { return read_id_and_representation_to_all_its_sketch_elements_; }
-        const std::map<representation_t, ArrayBlock>& representation_to_all_its_sketch_elements() const override { return representation_to_all_its_sketch_elements_; }
+        const std::vector<std::vector<Index::RepresentationToSketchElements>>& read_id_and_representation_to_sketch_elements() const override { return read_id_and_representation_to_sketch_elements_; }
 
         // setters
         void positions_in_reads(const std::vector<position_in_read_t>& val) { positions_in_reads_ = val; }
@@ -87,16 +86,15 @@ namespace claragenomics {
         void directions_of_reads(const std::vector<SketchElement::DirectionOfRepresentation>& val) { directions_of_reads_ = val; }
         void number_of_reads(std::uint64_t val) { number_of_reads_ = val; }
         void read_id_to_read_name(const std::vector<std::string>& val) { read_id_to_read_name_ = val; }
-        void read_id_and_representation_to_all_its_sketch_elements(const std::vector<std::map<representation_t, ArrayBlock>>& val) { read_id_and_representation_to_all_its_sketch_elements_ = val; }
-        void representation_to_all_its_sketch_elements(const std::map<representation_t, ArrayBlock>& val) { representation_to_all_its_sketch_elements_ = val; }
+        void read_id_and_representation_to_sketch_elements( const std::vector<std::vector<RepresentationToSketchElements>>& val ) { read_id_and_representation_to_sketch_elements_ = val; }
+
     private:
         std::vector<position_in_read_t> positions_in_reads_;
         std::vector<read_id_t> read_ids_;
         std::vector<SketchElement::DirectionOfRepresentation> directions_of_reads_;
         std::uint64_t number_of_reads_;
         std::vector<std::string> read_id_to_read_name_;
-        std::vector<std::map<representation_t, ArrayBlock>> read_id_and_representation_to_all_its_sketch_elements_;
-        std::map<representation_t, ArrayBlock> representation_to_all_its_sketch_elements_;
+        std::vector<std::vector<RepresentationToSketchElements>> read_id_and_representation_to_sketch_elements_;
     };
 
     TEST(TestCudamapperMatcher, CustomIndexTwoReads) {
@@ -118,14 +116,11 @@ namespace claragenomics {
 
         // no need for read_id_to_read_name
 
-        std::vector<std::map<representation_t, ArrayBlock>> read_id_and_representation_to_all_its_sketch_elements(2);
-        read_id_and_representation_to_all_its_sketch_elements[0].emplace(0x023, ArrayBlock{0,50});
-        read_id_and_representation_to_all_its_sketch_elements[1].emplace(0x023, ArrayBlock{50,50});
-        test_index.read_id_and_representation_to_all_its_sketch_elements(read_id_and_representation_to_all_its_sketch_elements);
-
-        std::map<representation_t, ArrayBlock> representation_to_all_its_sketch_elements;
-        representation_to_all_its_sketch_elements.emplace(0x023, ArrayBlock{0,100});
-        test_index.representation_to_all_its_sketch_elements(representation_to_all_its_sketch_elements);
+        // pointers
+        std::vector<std::vector<Index::RepresentationToSketchElements>> read_id_and_representation_to_sketch_elements(2);
+        read_id_and_representation_to_sketch_elements[0].emplace_back(Index::RepresentationToSketchElements{0x23, {0,50}, {0,100}});
+        read_id_and_representation_to_sketch_elements[1].emplace_back(Index::RepresentationToSketchElements{0x23, {50,50}, {0,100}});
+        test_index.read_id_and_representation_to_sketch_elements(read_id_and_representation_to_sketch_elements);
 
         Matcher matcher(test_index);
 
@@ -221,35 +216,24 @@ namespace claragenomics {
 
         // no need for read_id_to_read_name
 
-        // read_id_and_representation_to_all_its_sketch_elements
-        std::vector<std::map<representation_t, ArrayBlock>> read_id_and_representation_to_all_its_sketch_elements(4);
-        read_id_and_representation_to_all_its_sketch_elements[0].emplace(0, ArrayBlock{0,50});
-        read_id_and_representation_to_all_its_sketch_elements[3].emplace(1, ArrayBlock{50,80});
-        read_id_and_representation_to_all_its_sketch_elements[0].emplace(2, ArrayBlock{130,20});
-        read_id_and_representation_to_all_its_sketch_elements[1].emplace(2, ArrayBlock{150,30});
-        read_id_and_representation_to_all_its_sketch_elements[0].emplace(3, ArrayBlock{180,130});
-        read_id_and_representation_to_all_its_sketch_elements[1].emplace(3, ArrayBlock{310,70});
-        read_id_and_representation_to_all_its_sketch_elements[2].emplace(3, ArrayBlock{380,100});
-        read_id_and_representation_to_all_its_sketch_elements[3].emplace(3, ArrayBlock{480,80});
-        read_id_and_representation_to_all_its_sketch_elements[1].emplace(4, ArrayBlock{560,60});
-        read_id_and_representation_to_all_its_sketch_elements[2].emplace(4, ArrayBlock{620,100});
-        read_id_and_representation_to_all_its_sketch_elements[0].emplace(5, ArrayBlock{720,70});
-        read_id_and_representation_to_all_its_sketch_elements[1].emplace(5, ArrayBlock{790,40});
-        read_id_and_representation_to_all_its_sketch_elements[2].emplace(5, ArrayBlock{830,100});
-        read_id_and_representation_to_all_its_sketch_elements[3].emplace(5, ArrayBlock{930,80});
-        read_id_and_representation_to_all_its_sketch_elements[3].emplace(7, ArrayBlock{1010,80});
-        test_index.read_id_and_representation_to_all_its_sketch_elements(read_id_and_representation_to_all_its_sketch_elements);
-
-        // representation_to_all_its_sketch_elements
-        std::map<representation_t, ArrayBlock> representation_to_all_its_sketch_elements;
-        representation_to_all_its_sketch_elements.emplace(0, ArrayBlock{0,50});
-        representation_to_all_its_sketch_elements.emplace(1, ArrayBlock{50,80});
-        representation_to_all_its_sketch_elements.emplace(2, ArrayBlock{130,50});
-        representation_to_all_its_sketch_elements.emplace(3, ArrayBlock{180,380});
-        representation_to_all_its_sketch_elements.emplace(4, ArrayBlock{560,160});
-        representation_to_all_its_sketch_elements.emplace(5, ArrayBlock{720,290});
-        representation_to_all_its_sketch_elements.emplace(7, ArrayBlock{1010,80});
-        test_index.representation_to_all_its_sketch_elements(representation_to_all_its_sketch_elements);
+        // pointers
+        std::vector<std::vector<Index::RepresentationToSketchElements>> read_id_and_representation_to_sketch_elements(4);
+        read_id_and_representation_to_sketch_elements[0].emplace_back(Index::RepresentationToSketchElements{0, {0,   50},  {0,   50}});
+        read_id_and_representation_to_sketch_elements[3].emplace_back(Index::RepresentationToSketchElements{1, {50,  80},  {50,  80}});
+        read_id_and_representation_to_sketch_elements[0].emplace_back(Index::RepresentationToSketchElements{2, {130, 20},  {130, 50}});
+        read_id_and_representation_to_sketch_elements[1].emplace_back(Index::RepresentationToSketchElements{2, {150, 30},  {130, 50}});
+        read_id_and_representation_to_sketch_elements[0].emplace_back(Index::RepresentationToSketchElements{3, {180, 130}, {180, 380}});
+        read_id_and_representation_to_sketch_elements[1].emplace_back(Index::RepresentationToSketchElements{3, {310, 70},  {180, 380}});
+        read_id_and_representation_to_sketch_elements[2].emplace_back(Index::RepresentationToSketchElements{3, {380, 100}, {180, 380}});
+        read_id_and_representation_to_sketch_elements[3].emplace_back(Index::RepresentationToSketchElements{3, {480, 80},  {180, 380}});
+        read_id_and_representation_to_sketch_elements[1].emplace_back(Index::RepresentationToSketchElements{4, {560, 60},  {560, 160}});
+        read_id_and_representation_to_sketch_elements[2].emplace_back(Index::RepresentationToSketchElements{4, {620, 100}, {560, 160}});
+        read_id_and_representation_to_sketch_elements[0].emplace_back(Index::RepresentationToSketchElements{5, {720, 70},  {720, 290}});
+        read_id_and_representation_to_sketch_elements[1].emplace_back(Index::RepresentationToSketchElements{5, {790, 40},  {720, 290}});
+        read_id_and_representation_to_sketch_elements[2].emplace_back(Index::RepresentationToSketchElements{5, {830, 100}, {720, 290}});
+        read_id_and_representation_to_sketch_elements[3].emplace_back(Index::RepresentationToSketchElements{5, {930, 80},  {720, 290}});
+        read_id_and_representation_to_sketch_elements[3].emplace_back(Index::RepresentationToSketchElements{7, {1010,80},  {1010,80}});
+        test_index.read_id_and_representation_to_sketch_elements(read_id_and_representation_to_sketch_elements);
 
         Matcher matcher(test_index);
 


### PR DESCRIPTION
Using `std::vector` instead of `std::map` in Index<->Matcher interface.
This change has a huge performance benefit.
@akkamesh FYI