### PR TITLE
[cudapoa] make api functions device neutral

### DIFF
--- a/cudapoa/src/allocate_block.cpp
+++ b/cudapoa/src/allocate_block.cpp
@@ -28,6 +28,8 @@ BatchBlock::BatchBlock(int32_t device_id, size_t avail_mem, int32_t max_sequence
     , device_id_(throw_on_negative(device_id, "Device ID has to be non-negative"))
     , output_mask_(output_mask)
 {
+    scoped_device_switch dev(device_id_);
+
     matrix_sequence_dimension_ = banded_alignment_ ? CUDAPOA_BANDED_MAX_MATRIX_SEQUENCE_DIMENSION : CUDAPOA_MAX_MATRIX_SEQUENCE_DIMENSION;
     max_graph_dimension_       = banded_alignment_ ? CUDAPOA_MAX_MATRIX_GRAPH_DIMENSION_BANDED : CUDAPOA_MAX_MATRIX_GRAPH_DIMENSION;
     max_nodes_per_window_      = banded_alignment_ ? CUDAPOA_MAX_NODES_PER_WINDOW_BANDED : CUDAPOA_MAX_NODES_PER_WINDOW;
@@ -60,7 +62,6 @@ BatchBlock::BatchBlock(int32_t device_id, size_t avail_mem, int32_t max_sequence
     total_d_     = avail_mem;
 
     // Allocate.
-    CGA_CU_CHECK_ERR(cudaSetDevice(device_id_));
     CGA_CU_CHECK_ERR(cudaHostAlloc((void**)&block_data_h_, total_h_, cudaHostAllocDefault));
     CGA_CU_CHECK_ERR(cudaMalloc((void**)&block_data_d_, total_d_));
 }

--- a/cudapoa/src/cudapoa_batch.cpp
+++ b/cudapoa/src/cudapoa_batch.cpp
@@ -91,10 +91,11 @@ CudapoaBatch::CudapoaBatch(int32_t max_sequences_per_poa,
                                   cuda_banded_alignment))
     , max_poas_(batch_block_->get_max_poas())
 {
+    scoped_device_switch dev(device_id_);
+
     bid_ = CudapoaBatch::batches++;
 
     // Set CUDA device
-    CGA_CU_CHECK_ERR(cudaSetDevice(device_id_));
     std::string msg = " Initializing batch on device ";
     print_batch_debug_message(msg);
 
@@ -135,7 +136,8 @@ int32_t CudapoaBatch::get_total_poas() const
 
 void CudapoaBatch::generate_poa()
 {
-    CGA_CU_CHECK_ERR(cudaSetDevice(device_id_));
+    scoped_device_switch dev(device_id_);
+
     //Copy sequencecs, sequence lengths and window details to device
     CGA_CU_CHECK_ERR(cudaMemcpyAsync(input_details_d_->sequences, input_details_h_->sequences,
                                      num_nucleotides_copied_ * sizeof(uint8_t), cudaMemcpyHostToDevice, stream_));

--- a/cudapoa/src/cudapoa_batch.cpp
+++ b/cudapoa/src/cudapoa_batch.cpp
@@ -91,11 +91,11 @@ CudapoaBatch::CudapoaBatch(int32_t max_sequences_per_poa,
                                   cuda_banded_alignment))
     , max_poas_(batch_block_->get_max_poas())
 {
+    // Set CUDA device
     scoped_device_switch dev(device_id_);
 
     bid_ = CudapoaBatch::batches++;
 
-    // Set CUDA device
     std::string msg = " Initializing batch on device ";
     print_batch_debug_message(msg);
 


### PR DESCRIPTION
Making `cudapoa` API device neutral

Closes #113 