### PR TITLE
[common] clear CUDA runtime error in device_buffer before exception is thrown

### DIFF
--- a/common/utils/include/claragenomics/utils/device_buffer.cuh
+++ b/common/utils/include/claragenomics/utils/device_buffer.cuh
@@ -48,7 +48,16 @@ public:
     {
         cudaError_t err = cudaMalloc(reinterpret_cast<void**>(&data_), size_ * sizeof(T));
         if (err == cudaErrorMemoryAllocation)
+        {
+            // Clear the error from the runtime...
+            err = cudaGetLastError();
+            // Did a different async error happen in the meantime?
+            if (err != cudaErrorMemoryAllocation)
+            {
+                CGA_CU_CHECK_ERR(err);
+            }
             throw device_memory_allocation_exception();
+        }
         CGA_CU_CHECK_ERR(err);
     }
 


### PR DESCRIPTION
Clear the CUDA runtime error in device_buffer before an out-of-memory exception is thrown.