### PR TITLE
[cudamapper] Default constructor for Anchor

### DIFF
--- a/cudamapper/include/cudamapper/types.hpp
+++ b/cudamapper/include/cudamapper/types.hpp
@@ -36,6 +36,8 @@ using read_id_t = std::uint64_t; // can this be 32-bit?
 ///
 /// Anchor is a pair of two sketch elements with the same sketch element representation from different reads
 struct Anchor{
+    /// empty default constructor to prevent costly instantiations of all elements when initializing containers
+    Anchor(){}
     /// read ID of query
     read_id_t query_read_id_;
     /// read ID of target

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -549,7 +549,7 @@ namespace index_gpu {
 
             // fasta_objects not needed after this point
             fasta_objects.clear();
-            fasta_objects.reserve(0);
+            fasta_objects.shrink_to_fit();
 
             // move basepairs to the device
             CGA_LOG_INFO("Allocating {} bytes for read_id_to_basepairs_section_d", read_id_to_basepairs_section_h.size() * sizeof(decltype(read_id_to_basepairs_section_h)::value_type));
@@ -570,7 +570,7 @@ namespace index_gpu {
                                        )
                             );
             merged_basepairs_h.clear();
-            merged_basepairs_h.reserve(0);
+            merged_basepairs_h.shrink_to_fit();
 
             // sketch elements get generated here
             auto sketch_elements = SketchElementImpl::generate_sketch_elements(number_of_reads_to_add,
@@ -652,9 +652,9 @@ namespace index_gpu {
         }
 
         representations_from_all_loops_h.clear();
-        representations_from_all_loops_h.reserve(0);
+        representations_from_all_loops_h.shrink_to_fit();
         rest_from_all_loops_h.clear();
-        rest_from_all_loops_h.reserve(0);
+        rest_from_all_loops_h.shrink_to_fit();
 
         // build read_id_and_representation_to_sketch_elements_ and copy sketch elements to output arrays
         // TODO: This part takes a significant amount out time, think of a way to accelerate it

--- a/cudamapper/src/matcher.cu
+++ b/cudamapper/src/matcher.cu
@@ -261,7 +261,7 @@ namespace claragenomics {
                                         cudaMemcpyHostToDevice));
 
             read_id_to_sketch_elements_h.clear();
-            read_id_to_sketch_elements_h.reserve(0);
+            read_id_to_sketch_elements_h.shrink_to_fit();
 
             CGA_LOG_INFO("Allocating {} bytes for read_id_to_sketch_elements_to_check_d",
                          read_id_to_sketch_elements_to_check_h.size() * sizeof(ArrayBlock));
@@ -272,17 +272,16 @@ namespace claragenomics {
                                         read_id_to_sketch_elements_to_check_h.size() * sizeof(ArrayBlock),
                                         cudaMemcpyHostToDevice));
             read_id_to_sketch_elements_to_check_h.clear();
-            read_id_to_sketch_elements_to_check_h.reserve(0);
+            read_id_to_sketch_elements_to_check_h.shrink_to_fit();
 
             CGA_LOG_INFO("Allocating {} bytes for read_id_to_pointer_arrays_section_d",
                          read_id_to_pointer_arrays_section_h.size() * sizeof(ArrayBlock));
             device_buffer<ArrayBlock> read_id_to_pointer_arrays_section_d(read_id_to_pointer_arrays_section_h.size());
-            CGA_CU_CHECK_ERR(
-                    cudaMemcpy(read_id_to_pointer_arrays_section_d.data(), read_id_to_pointer_arrays_section_h.data(),
-                               read_id_to_pointer_arrays_section_h.size() * sizeof(ArrayBlock),
-                               cudaMemcpyHostToDevice));
+            CGA_CU_CHECK_ERR(cudaMemcpy(read_id_to_pointer_arrays_section_d.data(), read_id_to_pointer_arrays_section_h.data(),
+                                        read_id_to_pointer_arrays_section_h.size() * sizeof(ArrayBlock),
+                                        cudaMemcpyHostToDevice));
             read_id_to_pointer_arrays_section_h.clear();
-            read_id_to_pointer_arrays_section_h.reserve(0);
+            read_id_to_pointer_arrays_section_h.shrink_to_fit();
 
             CGA_LOG_INFO("Allocating {} bytes for anchors_d", total_anchors * sizeof(Anchor));
             device_buffer<Anchor> anchors_d(total_anchors);
@@ -294,7 +293,7 @@ namespace claragenomics {
                                         read_id_to_anchors_section_h.size() * sizeof(ArrayBlock),
                                         cudaMemcpyHostToDevice));
             read_id_to_anchors_section_h.clear();
-            read_id_to_anchors_section_h.reserve(0);
+            read_id_to_anchors_section_h.shrink_to_fit();
 
             generate_anchors <<<index.number_of_reads(), 32, largest_block_size * sizeof(position_in_read_t)>>>
                                                                (positions_in_reads_d.data(),


### PR DESCRIPTION
Implicit default constructor default-initializes members of the class. This is costly when `std::vector` of that class is created, only to have new values cudaMemcpy-ed into it. In such cases no initialization is needed. This PR defines default constructor for `Anchor` which does not initilialize any member and is thus not called by the constructor.

PR also bring changes where `std::vector::shrink_to_fit()` is called to free up memory instead of `std::vector::resize(0)` which had no effect.