### PR TITLE
[cudapoa] returning error when consensus/msa larger than max size

### DIFF
--- a/cudapoa/include/claragenomics/cudapoa/batch.hpp
+++ b/cudapoa/include/claragenomics/cudapoa/batch.hpp
@@ -83,6 +83,8 @@ public:
     ///                 base in each consensus string is returned
     /// \param output_status Reference to vector where the errors
     ///                 during kernel execution is captured
+    ///
+    /// \return Status indicating whether consensus generation is available for this batch.
     virtual StatusType get_consensus(std::vector<std::string>& consensus,
                                      std::vector<std::vector<uint16_t>>& coverage,
                                      std::vector<claragenomics::cudapoa::StatusType>& output_status) = 0;
@@ -93,6 +95,8 @@ public:
     ///                 poa is returned
     /// \param output_status Reference to vector where the errors
     ///                 during kernel execution is captured
+    ///
+    /// \return Status indicating whether MSA generation is available for this batch.
     virtual StatusType get_msa(std::vector<std::vector<std::string>>& msa,
                                std::vector<StatusType>& output_status) = 0;
 

--- a/cudapoa/src/cudapoa_batch.cpp
+++ b/cudapoa/src/cudapoa_batch.cpp
@@ -183,14 +183,20 @@ void CudapoaBatch::decode_cudapoa_kernel_error(claragenomics::cudapoa::StatusTyp
         output_status.emplace_back(error_type);
         break;
     case claragenomics::cudapoa::StatusType::seq_len_exceeded_maximum_nodes_per_window:
-        CGA_LOG_WARN("Kernel Error::Sequence length exceeded maximum nodes per window in batch {}\n", bid_);
+        CGA_LOG_WARN("Kernel Error:: Sequence length exceeded maximum nodes per window in batch {}\n", bid_);
         output_status.emplace_back(error_type);
         break;
     case claragenomics::cudapoa::StatusType::loop_count_exceeded_upper_bound:
-        CGA_LOG_WARN("Kernel Error::Loop count exceeded upper bound in nw algorithm in batch {}\n", bid_);
+        CGA_LOG_WARN("Kernel Error:: Loop count exceeded upper bound in nw algorithm in batch {}\n", bid_);
+        output_status.emplace_back(error_type);
+        break;
+    case claragenomics::cudapoa::StatusType::exceeded_maximum_sequence_size:
+        CGA_LOG_WARN("Kernel Error:: Consensus/MSA sequence size exceeded max sequence size in batch {}\n", bid_);
         output_status.emplace_back(error_type);
         break;
     default:
+        CGA_LOG_WARN("Kernel Error:: Unknown error in batch {}\n", bid_);
+        output_status.emplace_back(error_type);
         break;
     }
 }

--- a/cudapoa/src/cudapoa_generate_msa.cu
+++ b/cudapoa/src/cudapoa_generate_msa.cu
@@ -186,9 +186,18 @@ __global__ void generateMSAKernel(uint8_t* nodes_d,
                                              sorted_poa,
                                              node_id_to_msa_pos,
                                              node_alignment_counts);
+
+        if (msa_length >= CUDAPOA_MAX_CONSENSUS_SIZE)
+        {
+            consensus[0] = CUDAPOA_KERNEL_ERROR_ENCOUNTERED;
+            consensus[1] = static_cast<uint8_t>(StatusType::exceeded_maximum_sequence_size);
+        }
     }
 
     __syncthreads();
+
+    if (consensus[0] == CUDAPOA_KERNEL_ERROR_ENCOUNTERED)
+        return;
 
     generateMSADevice(nodes,
                       num_sequences,


### PR DESCRIPTION
Improving error checking for msa/consensus generation in cudapoa kernels

Fixes #171 