### PR TITLE
[pyclaragenomics] `paf_eval` bugfix and lint

### DIFF
--- a/pyclaragenomics/bin/evaluate_paf
+++ b/pyclaragenomics/bin/evaluate_paf
@@ -34,6 +34,16 @@ def match_overlaps(query_0, query_1, target_0, target_1, pos_tolerance):
         abs(target_0[0] - target_1[0]) < pos_tolerance and \
         abs(target_0[1] - target_1[1]) < pos_tolerance
 
+def generate_key(name_1, name_2):
+    """Given two read names, return key for indexing overlaps.
+
+    Args:
+        name_1 (str) : Name of first read
+        name_2 (str): Name of second read
+
+    Returns: a key of concatenated names.
+    """
+    return "{}_{}".format(name_1, name_2)
 
 def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_self_mappings=True):
     """Given a truth and test set PAF file, count number of in/correctly detected, and non-detected overlaps
@@ -55,7 +65,7 @@ def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_
                 (truth_overlap.query_sequence_name == truth_overlap.target_sequence_name):
             continue
 
-        key = truth_overlap.query_sequence_name + "_" + truth_overlap.target_sequence_name
+        key = generate_key(truth_overlap.query_sequence_name, truth_overlap.target_sequence_name)
 
         truth_overlaps[key].append(truth_overlap)
         num_true_overlaps += 1
@@ -76,8 +86,8 @@ def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_
         query_0 = (test_overlap.query_start, test_overlap.query_end)
         target_0 = (test_overlap.target_start, test_overlap.target_end)
 
-        key = test_overlap.query_sequence_name + "_" + test_overlap.target_sequence_name
-        key_reversed = test_overlap.target_sequence_name + "_" + test_overlap.query_sequence_name
+        key = generate_key(test_overlap.query_sequence_name, test_overlap.target_sequence_name)
+        key_reversed = generate_key(test_overlap.target_sequence_name, test_overlap.query_sequence_name)
 
         if (key in seen_test_overlap_keys) or (key_reversed in seen_test_overlap_keys):
             continue

--- a/pyclaragenomics/bin/evaluate_paf
+++ b/pyclaragenomics/bin/evaluate_paf
@@ -16,6 +16,7 @@ from collections import defaultdict
 
 from claragenomics.io import pafio
 
+
 def match_overlaps(query_0, query_1, target_0, target_1, pos_tolerance):
     """Given two sets of query and target ranges, check if the query and target ranges
     fall within a specified tolerance of each other.
@@ -32,6 +33,7 @@ def match_overlaps(query_0, query_1, target_0, target_1, pos_tolerance):
         abs(query_0[1] - query_1[1]) < pos_tolerance and \
         abs(target_0[0] - target_1[0]) < pos_tolerance and \
         abs(target_0[1] - target_1[1]) < pos_tolerance
+
 
 def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_self_mappings=True):
     """Given a truth and test set PAF file, count number of in/correctly detected, and non-detected overlaps
@@ -53,7 +55,7 @@ def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_
                 (truth_overlap.query_sequence_name == truth_overlap.target_sequence_name):
             continue
 
-        key = truth_overlap.query_sequence_name + truth_overlap.target_sequence_name
+        key = truth_overlap.query_sequence_name + "_" + truth_overlap.target_sequence_name
 
         truth_overlaps[key].append(truth_overlap)
         num_true_overlaps += 1
@@ -61,6 +63,10 @@ def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_
     true_positive_count = 0
     false_positive_count = 0
     false_negative_count = 0
+
+    print("Counted {} true overlaps".format(num_true_overlaps))
+
+    seen_test_overlap_keys = set()
 
     for test_overlap in pafio.read_paf(test_paf_filepath):
         if skip_self_mappings and \
@@ -70,8 +76,14 @@ def evaluate_paf(truth_paf_filepath, test_paf_filepath, pos_tolerance=400, skip_
         query_0 = (test_overlap.query_start, test_overlap.query_end)
         target_0 = (test_overlap.target_start, test_overlap.target_end)
 
-        key = test_overlap.query_sequence_name + test_overlap.target_sequence_name
+        key = test_overlap.query_sequence_name + "_" + test_overlap.target_sequence_name
         key_reversed = test_overlap.target_sequence_name + "_" + test_overlap.query_sequence_name
+
+        if (key in seen_test_overlap_keys) or (key_reversed in seen_test_overlap_keys):
+            continue
+
+        seen_test_overlap_keys.add(key)
+        seen_test_overlap_keys.add(key_reversed)
 
         found_match = False
         if key in truth_overlaps:
@@ -125,8 +137,12 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    true_positives, false_positives, false_negatives = evaluate_paf(args.truth_paf, args.test_paf, \
-            args.pos_tolerance, args.skip_self_mapping)
+    true_positives, false_positives, false_negatives = evaluate_paf(args.truth_paf, args.test_paf,
+                                                                    args.pos_tolerance, args.skip_self_mapping)
+
+    print("True positives: ", true_positives)
+    print("False positives: ", false_positives)
+    print("False negatives: ", false_negatives)
 
     precision = true_positives / (true_positives + false_positives)
     recall = true_positives / (true_positives + false_negatives)


### PR DESCRIPTION
* Fixed bug whereby if query and target were reversed in order overlaps
were not being evaluated
* Linted for PEP8 compliance
* Added printing of TP,FP and FN absolute numbers