### PR TITLE
[ci] nvidia-docker2 runtime is depricated since 19.3.0.

### DIFF
--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -132,20 +132,18 @@ sudo docker pull "${DOCKER_IMAGE}"
 DOCKER_VERSION_WITH_GPU_SUPPORT="19.03.0"
 DOCKER_VERSION=$(docker version | grep -i version | head -1 | awk '{print $2'})
 
+PARAM_RUNTIME="--runtime=nvidia"
+PARAM_ALL_GPU="-e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}"
+
 if [ "$DOCKER_VERSION_WITH_GPU_SUPPORT" == "$(echo -e "$DOCKER_VERSION\n$DOCKER_VERSION_WITH_GPU_SUPPORT" | sort -V | head -1)" ]; then
-    sudo docker run --rm -it --gpus all\
-        -u "$(id -u)":"$(id -g)" \
-        -v "${REPO_PATH}":"${REPO_PATH_IN_CONTAINER}" \
-        -v "$PASSWD_FILE":/etc/passwd:ro \
-        -v "$GROUP_FILE":/etc/group:ro \
-        --cap-add=SYS_PTRACE \
-        "${DOCKER_IMAGE}" bash -c "${COMMAND}"
-else
-    sudo docker run --runtime=nvidia --rm -it -e NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES}" \
-        -u "$(id -u)":"$(id -g)" \
-        -v "${REPO_PATH}":"${REPO_PATH_IN_CONTAINER}" \
-        -v "$PASSWD_FILE":/etc/passwd:ro \
-        -v "$GROUP_FILE":/etc/group:ro \
-        --cap-add=SYS_PTRACE \
-        "${DOCKER_IMAGE}" bash -c "${COMMAND}"
+    PARAM_RUNTIME=""
+    PARAM_ALL_GPU="--gpus ${NVIDIA_VISIBLE_DEVICES}"
 fi
+
+sudo docker run $PARAM_RUNTIME --rm -it $PARAM_ALL_GPU \
+    -u "$(id -u)":"$(id -g)" \
+    -v "${REPO_PATH}":"${REPO_PATH_IN_CONTAINER}" \
+    -v "$PASSWD_FILE":/etc/passwd:ro \
+    -v "$GROUP_FILE":/etc/group:ro \
+    --cap-add=SYS_PTRACE \
+    "${DOCKER_IMAGE}" bash -c "${COMMAND}"

--- a/ci/local/build.sh
+++ b/ci/local/build.sh
@@ -133,14 +133,14 @@ DOCKER_VERSION_WITH_GPU_SUPPORT="19.03.0"
 DOCKER_VERSION=$(docker version | grep -i version | head -1 | awk '{print $2'})
 
 PARAM_RUNTIME="--runtime=nvidia"
-PARAM_ALL_GPU="-e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}"
+PARAM_GPUS="-e NVIDIA_VISIBLE_DEVICES=${NVIDIA_VISIBLE_DEVICES}"
 
 if [ "$DOCKER_VERSION_WITH_GPU_SUPPORT" == "$(echo -e "$DOCKER_VERSION\n$DOCKER_VERSION_WITH_GPU_SUPPORT" | sort -V | head -1)" ]; then
     PARAM_RUNTIME=""
-    PARAM_ALL_GPU="--gpus ${NVIDIA_VISIBLE_DEVICES}"
+    PARAM_GPUS="--gpus ${NVIDIA_VISIBLE_DEVICES}"
 fi
 
-sudo docker run $PARAM_RUNTIME --rm -it $PARAM_ALL_GPU \
+sudo docker run $PARAM_RUNTIME --rm -it $PARAM_GPUS \
     -u "$(id -u)":"$(id -g)" \
     -v "${REPO_PATH}":"${REPO_PATH_IN_CONTAINER}" \
     -v "$PASSWD_FILE":/etc/passwd:ro \


### PR DESCRIPTION
This script fails when used with "nvidia-container-toolkit" (recommended for GPU support)
Please refer https://github.com/NVIDIA/nvidia-docker

This change allows different 'docker run' command to start the CI
pipeline based on docker version.