### PR TITLE
[cudamapper] No device shrink_to_fit in Index

### DIFF
--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -56,9 +56,7 @@ void find_first_occurrences_of_representations(thrust::device_vector<representat
     const std::uint64_t number_of_unique_representations = representation_index_mask_d.back(); // D2H copy
 
     first_occurrence_index_d.resize(number_of_unique_representations + 1); // <- +1 for the additional element
-    first_occurrence_index_d.shrink_to_fit();
     unique_representations_d.resize(number_of_unique_representations);
-    unique_representations_d.shrink_to_fit();
 
     find_first_occurrences_of_representations_kernel<<<number_of_blocks, number_of_threads>>>(representation_index_mask_d.data().get(),
                                                                                               input_representations_d.data().get(),

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -55,7 +55,11 @@ void find_first_occurrences_of_representations(thrust::device_vector<representat
     const std::uint64_t number_of_unique_representations = representation_index_mask_d.back(); // D2H copy
 
     first_occurrence_index_d.resize(number_of_unique_representations + 1); // <- +1 for the additional element
+    if (first_occurrence_index_d.capacity() > first_occurrence_index_d.size())
+        first_occurrence_index_d.shrink_to_fit();
     unique_representations_d.resize(number_of_unique_representations);
+    if (unique_representations_d.capacity() > unique_representations_d.size())
+        unique_representations_d.shrink_to_fit();
 
     find_first_occurrences_of_representations_kernel<<<number_of_blocks, number_of_threads>>>(representation_index_mask_d.data().get(),
                                                                                               input_representations_d.data().get(),

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -697,6 +697,8 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
 
     // copy the data to member functions (depending on the interface desing these copies might not be needed)
     representations_d_.resize(representations_d.size());
+    if (representations_d_.capacity() > representations_d_.size())
+        representations_d_.shrink_to_fit();
     thrust::copy(thrust::device,
                  representations_d.data(),
                  representations_d.data() + representations_d.size(),
@@ -704,8 +706,14 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
     representations_d.free();
 
     read_ids_d_.resize(representations_d_.size());
+    if (read_ids_d_.capacity() > read_ids_d_.size())
+        read_ids_d_.shrink_to_fit();
     positions_in_reads_d_.resize(representations_d_.size());
+    if (positions_in_reads_d_.capacity() > positions_in_reads_d_.size())
+        positions_in_reads_d_.shrink_to_fit();
     directions_of_reads_d_.resize(representations_d_.size());
+    if (directions_of_reads_d_.capacity() > directions_of_reads_d_.size())
+        directions_of_reads_d_.shrink_to_fit();
 
     const std::uint32_t threads = 256;
     const std::uint32_t blocks  = ceiling_divide<int64_t>(representations_d_.size(), threads);

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -386,7 +386,6 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
 
     // copy the data to member functions (depending on the interface desing these copies might not be needed)
     representations_d_.resize(representations_d.size());
-    representations_d_.shrink_to_fit();
     thrust::copy(thrust::device,
                  representations_d.data(),
                  representations_d.data() + representations_d.size(),
@@ -394,11 +393,8 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
     representations_d.free();
 
     read_ids_d_.resize(representations_d_.size());
-    read_ids_d_.shrink_to_fit();
     positions_in_reads_d_.resize(representations_d_.size());
-    positions_in_reads_d_.shrink_to_fit();
     directions_of_reads_d_.resize(representations_d_.size());
-    directions_of_reads_d_.shrink_to_fit();
 
     const std::uint32_t threads = 256;
     const std::uint32_t blocks  = ceiling_divide<int64_t>(representations_d_.size(), threads);


### PR DESCRIPTION
Generally speaking it's not necessary to do `shrink_to_fit()` after `resize()` for `thrust::device_vector`.

`resize(count)` allocates exactly `count` elements and `shrink_to_fit()` will do deallocation and allocation even it `size() == capacity()` (I started a discussion about this with Thrust developers).

We how only call `shrink_to_fit` if `capacity > size`