### PR TITLE
Create intermediate Fasta index and bgzip files in a separate directory...

### DIFF
--- a/common/io/CMakeLists.txt
+++ b/common/io/CMakeLists.txt
@@ -16,17 +16,19 @@ add_library(${PROJECT_NAME} ${cga_library_type}
         src/hts_fasta_parser.cpp)
 target_link_libraries(${PROJECT_NAME} PUBLIC hts)
 
+include_directories(../utils/include)
+
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include/claragenomics/io)
 
 target_include_directories(${PROJECT_NAME}
-    PUBLIC 
-        $<INSTALL_INTERFACE:include>    
+    PUBLIC
+        $<INSTALL_INTERFACE:include>
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
 )
 
 target_compile_options(${PROJECT_NAME} PRIVATE -Werror)
 
-install(TARGETS ${PROJECT_NAME} 
+install(TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}
     DESTINATION lib
     INCLUDES DESTINATION include

--- a/common/io/include/claragenomics/io/fasta_parser.hpp
+++ b/common/io/include/claragenomics/io/fasta_parser.hpp
@@ -59,7 +59,7 @@ public:
 /// \param fasta_file Path to FASTA(.gz) file. If .gz, it must be zipped with bgzip.
 ///
 /// \return A unique pointer to a constructed parser object.
-std::unique_ptr<FastaParser> create_fasta_parser(const std::string& fasta_file);
+std::unique_ptr<FastaParser> create_fasta_parser(const std::string& fasta_file, const std::string& output_dir);
 
 } // namespace io
 } // namespace claragenomics

--- a/common/io/src/fasta_parser.cpp
+++ b/common/io/src/fasta_parser.cpp
@@ -19,9 +19,9 @@ namespace claragenomics
 namespace io
 {
 
-std::unique_ptr<FastaParser> create_fasta_parser(const std::string& fasta_file)
+std::unique_ptr<FastaParser> create_fasta_parser(const std::string& fasta_file, const std::string& output_dir)
 {
-    return std::make_unique<FastaParserHTS>(fasta_file);
+    return std::make_unique<FastaParserHTS>(fasta_file, output_dir);
 }
 
 } // namespace io

--- a/common/io/src/hts_fasta_parser.cpp
+++ b/common/io/src/hts_fasta_parser.cpp
@@ -36,16 +36,17 @@ namespace io
 {
 
 FastaParserHTS::FastaParserHTS(const std::string& fasta_file,
-        const std::string& output_dir)
+                               const std::string& output_dir)
 {
     std::string fai_file = fasta_file + ".fai";
     std::string gzi_file = fasta_file + ".gzi";
     if (output_dir.length() != 0)
     {
         // resolve idx and gzi file path
-        if (!claragenomics::filesystem::dirExists(output_dir)) {
+        if (!claragenomics::filesystem::dirExists(output_dir))
+        {
             throw std::runtime_error("Output dir " + output_dir +
-                    " not found or not a directory!");
+                                     " not found or not a directory!");
         }
 
         std::string file_name =
@@ -55,8 +56,8 @@ FastaParserHTS::FastaParserHTS(const std::string& fasta_file,
     }
 
     fasta_index_ = fai_load3(
-            fasta_file.c_str(), fai_file.c_str(), gzi_file.c_str(),
-            FAI_CREATE);
+        fasta_file.c_str(), fai_file.c_str(), gzi_file.c_str(),
+        FAI_CREATE);
 
     if (fasta_index_ == NULL)
     {

--- a/common/io/src/hts_fasta_parser.cpp
+++ b/common/io/src/hts_fasta_parser.cpp
@@ -12,6 +12,7 @@
 
 #include <string>
 #include <memory>
+#include <claragenomics/utils/filesystem.hpp>
 
 extern "C" {
 #include <htslib/faidx.h>
@@ -34,9 +35,29 @@ namespace claragenomics
 namespace io
 {
 
-FastaParserHTS::FastaParserHTS(const std::string& fasta_file)
+FastaParserHTS::FastaParserHTS(const std::string& fasta_file,
+        const std::string& output_dir)
 {
-    fasta_index_ = fai_load3(fasta_file.c_str(), NULL, NULL, FAI_CREATE);
+    std::string fai_file = fasta_file + ".fai";
+    std::string gzi_file = fasta_file + ".gzi";
+    if (output_dir.length() != 0)
+    {
+        // resolve idx and gzi file path
+        if (!claragenomics::filesystem::dirExists(output_dir)) {
+            throw std::runtime_error("Output dir " + output_dir +
+                    " not found or not a directory!");
+        }
+
+        std::string file_name =
+            claragenomics::filesystem::resolveFileName(fasta_file);
+        fai_file = output_dir + "/" + file_name + ".fai";
+        gzi_file = output_dir + "/" + file_name + ".gzi";
+    }
+
+    fasta_index_ = fai_load3(
+            fasta_file.c_str(), fai_file.c_str(), gzi_file.c_str(),
+            FAI_CREATE);
+
     if (fasta_index_ == NULL)
     {
         throw std::runtime_error("Could not load fasta index!");

--- a/common/io/src/hts_fasta_parser.hpp
+++ b/common/io/src/hts_fasta_parser.hpp
@@ -26,7 +26,7 @@ namespace io
 class FastaParserHTS : public FastaParser
 {
 public:
-    FastaParserHTS(const std::string& fasta_file);
+    FastaParserHTS(const std::string& fasta_file, const std::string& tmp_dir);
     ~FastaParserHTS();
 
     int32_t get_num_seqences() const override;

--- a/common/utils/include/claragenomics/utils/filesystem.hpp
+++ b/common/utils/include/claragenomics/utils/filesystem.hpp
@@ -25,12 +25,12 @@ bool dirExists(const std::string path)
     struct stat info;
 
     int response = stat(path.c_str(), &info);
-    if( response != 0 )
+    if (response != 0)
     {
         return false;
     }
 
-    return ( info.st_mode & S_IFDIR ) ? true : false;
+    return (info.st_mode & S_IFDIR) ? true : false;
 }
 
 

--- a/common/utils/include/claragenomics/utils/filesystem.hpp
+++ b/common/utils/include/claragenomics/utils/filesystem.hpp
@@ -1,0 +1,46 @@
+/*
+* Copyright (c) 2019, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#pragma once
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <string>
+
+namespace claragenomics
+{
+
+namespace filesystem
+{
+
+bool dirExists(const std::string path)
+{
+    struct stat info;
+
+    int response = stat(path.c_str(), &info);
+    if( response != 0 )
+    {
+        return false;
+    }
+
+    return ( info.st_mode & S_IFDIR ) ? true : false;
+}
+
+
+std::string resolveFileName(const std::string file_path)
+{
+    size_t found;
+    found = file_path.find_last_of("/\\");
+    return file_path.substr(found + 1);
+}
+
+} //namespace filesystem
+
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/filesystem.hpp
+++ b/common/utils/include/claragenomics/utils/filesystem.hpp
@@ -33,7 +33,6 @@ bool dirExists(const std::string path)
     return (info.st_mode & S_IFDIR) ? true : false;
 }
 
-
 std::string resolveFileName(const std::string file_path)
 {
     size_t found;

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -55,7 +55,7 @@ int main(int argc, char* argv[])
     std::int32_t target_index_size = 10000; // t
     double filtering_parameter     = 1.0;   // F
     std::string output_dir;
-    std::string optstring          = "k:w:d:c:i:t:F:o:h:";
+    std::string optstring = "k:w:d:c:i:t:F:o:h:";
 
     uint32_t argument;
     while ((argument = getopt_long(argc, argv, optstring.c_str(), options, nullptr)) != -1)
@@ -369,7 +369,7 @@ void help(int32_t exit_code = 0)
               << R"(
         -F --filtering-parameter
             filter all representations for which sketch_elements_with_that_representation/total_sketch_elements >= filtering_parameter), filtering disabled if filtering_parameter == 1.0 [1'000'000'001] (Min = 0.0, Max = 1.0))"
-               << R"(
+              << R"(
         -o --output-dir
             directory for creating all intermedate files)"
               << std::endl;

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -37,6 +37,7 @@ static struct option options[] = {
     {"index-size", required_argument, 0, 'i'},
     {"target-index-size", required_argument, 0, 't'},
     {"filtering-parameter", required_argument, 0, 'F'},
+    {"output-dir", required_argument, 0, 'o'},
     {"help", no_argument, 0, 'h'},
 };
 
@@ -53,7 +54,9 @@ int main(int argc, char* argv[])
     std::int32_t index_size        = 10000; // i
     std::int32_t target_index_size = 10000; // t
     double filtering_parameter     = 1.0;   // F
-    std::string optstring          = "k:w:d:c:i:t:F:h:";
+    std::string output_dir;
+    std::string optstring          = "k:w:d:c:i:t:F:o:h:";
+
     uint32_t argument;
     while ((argument = getopt_long(argc, argv, optstring.c_str(), options, nullptr)) != -1)
     {
@@ -79,6 +82,9 @@ int main(int argc, char* argv[])
             break;
         case 'F':
             filtering_parameter = atof(optarg);
+            break;
+        case 'o':
+            output_dir = optarg;
             break;
         case 'h':
             help(0);
@@ -117,10 +123,10 @@ int main(int argc, char* argv[])
         std::cerr << "NOTE - Since query and target files are same, activating all_to_all mode. Query index size used for both files." << std::endl;
     }
 
-    std::unique_ptr<claragenomics::io::FastaParser> query_parser = claragenomics::io::create_fasta_parser(query_filepath);
+    std::unique_ptr<claragenomics::io::FastaParser> query_parser = claragenomics::io::create_fasta_parser(query_filepath, output_dir);
     int32_t queries                                              = query_parser->get_num_seqences();
 
-    std::unique_ptr<claragenomics::io::FastaParser> target_parser = claragenomics::io::create_fasta_parser(target_filepath);
+    std::unique_ptr<claragenomics::io::FastaParser> target_parser = claragenomics::io::create_fasta_parser(target_filepath, output_dir);
     int32_t targets                                               = target_parser->get_num_seqences();
 
     std::cerr << "Query " << query_filepath << " index " << queries << std::endl;
@@ -363,6 +369,9 @@ void help(int32_t exit_code = 0)
               << R"(
         -F --filtering-parameter
             filter all representations for which sketch_elements_with_that_representation/total_sketch_elements >= filtering_parameter), filtering disabled if filtering_parameter == 1.0 [1'000'000'001] (Min = 0.0, Max = 1.0))"
+               << R"(
+        -o --output-dir
+            directory for creating all intermedate files)"
               << std::endl;
 
     exit(exit_code);

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -1264,7 +1264,7 @@ void test_function(const std::string& filename,
                    const std::uint64_t expected_number_of_reads,
                    const double filtering_parameter = 1.0)
 {
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename);
+    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename, "");
     IndexGPU<Minimizer> index(*parser,
                               first_read_id,
                               past_the_last_read_id,

--- a/cudamapper/tests/Test_CudamapperMatcherGPU.cu
+++ b/cudamapper/tests/Test_CudamapperMatcherGPU.cu
@@ -329,9 +329,10 @@ TEST(TestCudamapperMatcherGPU, test_generate_anchors_small_example)
 
 TEST(TestCudamapperMatcherGPU, OneReadOneMinimizer)
 {
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> query_index      = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> target_index     = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<io::FastaParser> parser =
+        io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta", "");
+    std::unique_ptr<Index> query_index  = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> target_index = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
     MatcherGPU matcher(*query_index, *target_index);
 
     const thrust::host_vector<Anchor> anchors(matcher.anchors());
@@ -340,9 +341,10 @@ TEST(TestCudamapperMatcherGPU, OneReadOneMinimizer)
 
 TEST(TestCudamapperMatcherGPU, AtLeastOneIndexEmpty)
 {
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> index_full       = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> index_empty      = Index::create_index(*parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
+    std::unique_ptr<io::FastaParser> parser =
+        io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta", "");
+    std::unique_ptr<Index> index_full  = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> index_empty = Index::create_index(*parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
 
     {
         MatcherGPU matcher(*index_full, *index_empty);

--- a/cudamapper/tests/mock_index.cuh
+++ b/cudamapper/tests/mock_index.cuh
@@ -25,7 +25,8 @@ class MockIndex : public IndexGPU<Minimizer>
 {
 public:
     MockIndex()
-        : IndexGPU(*claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta"),
+        : IndexGPU(*claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta",
+                                                           std::string(CUDAMAPPER_BENCHMARK_DATA_DIR)),
                    0,
                    0,
                    0,


### PR DESCRIPTION
The directory containing ".fasta" file, is the default location for creating(htslib) Fasta index and bgzip files. This is a problem in environments such as Clara deploy, where the directory containing the input files is read-only.

These change circumvent this issue by allowing creation of these files in a temp/output directory. Temp directory is an optional input parameter(-o).