### PR TITLE
[cudamapper] Get the length of the longest read

### DIFF
--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -72,6 +72,10 @@ public:
     /// \return number of reads in input data
     virtual read_id_t number_of_reads() const = 0;
 
+    /// \brief returns length of the longest read in this index
+    /// \return length of the longest read in this index
+    virtual position_in_read_t number_of_basepairs_in_longest_read() const = 0;
+
     /// \brief Return the maximum kmer length allowable
     /// \return Return the maximum kmer length allowable
     static uint64_t maximum_kmer_size()

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -70,7 +70,7 @@ public:
 
     /// \brief returns number of reads in input data
     /// \return number of reads in input data
-    virtual std::uint64_t number_of_reads() const = 0;
+    virtual read_id_t number_of_reads() const = 0;
 
     /// \brief Return the maximum kmer length allowable
     /// \return Return the maximum kmer length allowable

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -103,7 +103,7 @@ public:
 
     /// \brief returns number of reads in input data
     /// \return number of reads in input data
-    std::uint64_t number_of_reads() const override;
+    read_id_t number_of_reads() const override;
 
 private:
     /// \brief generates the index
@@ -129,7 +129,7 @@ private:
     const std::uint64_t kmer_size_ = 0;
     // the number of adjacent k-mers in a window, adjacent = shifted by one basepair
     const std::uint64_t window_size_ = 0;
-    std::uint64_t number_of_reads_   = 0;
+    read_id_t number_of_reads_   = 0;
 };
 
 namespace details
@@ -581,7 +581,7 @@ const std::uint32_t& IndexGPU<SketchElementImpl>::read_id_to_read_length(const r
 }
 
 template <typename SketchElementImpl>
-std::uint64_t IndexGPU<SketchElementImpl>::number_of_reads() const
+read_id_t IndexGPU<SketchElementImpl>::number_of_reads() const
 {
     return number_of_reads_;
 }

--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -857,7 +857,7 @@ __global__ void compress_minimizers(const representation_t* const window_minimiz
     }
 }
 
-Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(const std::uint64_t number_of_reads_to_add,
+Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(const read_id_t number_of_reads_to_add,
                                                                        const std::uint64_t minimizer_size,
                                                                        const std::uint64_t window_size,
                                                                        const std::uint64_t read_id_of_first_read,

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -81,7 +81,7 @@ public:
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (host memory)
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (device memory)
     /// \param hash_minimizers if true, apply a hash function to the representations
-    static GeneratedSketchElements generate_sketch_elements(const std::uint64_t number_of_reads_to_add,
+    static GeneratedSketchElements generate_sketch_elements(const read_id_t number_of_reads_to_add,
                                                             const std::uint64_t minimizer_size,
                                                             const std::uint64_t window_size,
                                                             const std::uint64_t read_id_of_first_read,

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -1262,6 +1262,7 @@ void test_function(const std::string& filename,
                    const std::vector<std::string>& expected_read_id_to_read_name,
                    const std::vector<std::uint32_t>& expected_read_id_to_read_length,
                    const read_id_t expected_number_of_reads,
+                   const position_in_read_t expected_number_of_basepairs_in_longest_read,
                    const double filtering_parameter = 1.0)
 {
     std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename);
@@ -1278,6 +1279,8 @@ void test_function(const std::string& filename,
     {
         return;
     }
+
+    ASSERT_EQ(expected_number_of_basepairs_in_longest_read, index.number_of_basepairs_in_longest_read());
 
     ASSERT_EQ(expected_number_of_reads, expected_read_id_to_read_name.size());
     ASSERT_EQ(expected_number_of_reads, expected_read_id_to_read_length.size());
@@ -1360,6 +1363,9 @@ TEST(TestCudamapperIndexGPU, GATT_4_1)
 
     expected_first_occurrence_of_representations.push_back(1);
 
+    const read_id_t expected_number_of_reads                              = 1;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 4;
+
     test_function(filename,
                   0,
                   1,
@@ -1373,7 +1379,8 @@ TEST(TestCudamapperIndexGPU, GATT_4_1)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  1);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, GATT_2_3)
@@ -1443,6 +1450,9 @@ TEST(TestCudamapperIndexGPU, GATT_2_3)
 
     expected_first_occurrence_of_representations.push_back(3);
 
+    const read_id_t expected_number_of_reads                              = 1;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 4;
+
     test_function(filename,
                   0,
                   1,
@@ -1456,7 +1466,8 @@ TEST(TestCudamapperIndexGPU, GATT_2_3)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  1);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
@@ -1483,6 +1494,9 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
     std::vector<representation_t> expected_unique_representations;
     std::vector<std::uint32_t> expected_first_occurrence_of_representations;
 
+    const read_id_t expected_number_of_reads                              = 0;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 0;
+
     test_function(filename,
                   0,
                   1,
@@ -1496,7 +1510,8 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  0);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 // TODO: Cover this case as well
@@ -1571,6 +1586,9 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
 //    expected_read_ids.push_back(0);
 //    expected_directions_of_reads.push_back(SketchElement::DirectionOfRepresentation::REVERSE);
 //
+//    const read_id_t expected_number_of_reads                              = 1;
+//    const position_in_read_t expected_number_of_basepairs_in_longest_read = 7;
+//
 //    test_function(filename,
 //                  0,
 //                  2,
@@ -1582,7 +1600,8 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
 //                  expected_directions_of_reads,
 //                  expected_read_id_to_read_name,
 //                  expected_read_id_to_read_length,
-//                  1); // <- only one read goes into index, the other is too short
+//                  expected_number_of_reads,
+//                  expected_number_of_basepairs_in_longest_read); // <- only one read goes into index, the other is too short
 //}
 
 TEST(TestCudamapperIndexGPU, CCCATACC_3_5)
@@ -1674,6 +1693,9 @@ TEST(TestCudamapperIndexGPU, CCCATACC_3_5)
 
     expected_first_occurrence_of_representations.push_back(5);
 
+    const read_id_t expected_number_of_reads                              = 1;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 8;
+
     test_function(filename,
                   0,
                   1,
@@ -1687,7 +1709,8 @@ TEST(TestCudamapperIndexGPU, CCCATACC_3_5)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  1);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, CATCAAG_AAGCTA_3_2)
@@ -1809,6 +1832,9 @@ TEST(TestCudamapperIndexGPU, CATCAAG_AAGCTA_3_2)
 
     expected_first_occurrence_of_representations.push_back(7);
 
+    const read_id_t expected_number_of_reads                              = 2;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 7;
+
     test_function(filename,
                   0,
                   2,
@@ -1822,7 +1848,8 @@ TEST(TestCudamapperIndexGPU, CATCAAG_AAGCTA_3_2)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  2);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3)
@@ -1976,6 +2003,9 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3)
 
     expected_first_occurrence_of_representations.push_back(12);
 
+    const read_id_t expected_number_of_reads                              = 2;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 9;
+
     test_function(filename,
                   0,
                   2,
@@ -1989,7 +2019,8 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  2);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_only_second_read_in_index)
@@ -2089,6 +2120,9 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_only_second_read_in_index)
 
     expected_first_occurrence_of_representations.push_back(6);
 
+    const read_id_t expected_number_of_reads                              = 1;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 7;
+
     test_function(filename,
                   1, // <- only take second read
                   2,
@@ -2102,7 +2136,8 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_only_second_read_in_index)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  1);
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read);
 }
 
 TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_filtering)
@@ -2236,6 +2271,9 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_filtering)
 
     expected_first_occurrence_of_representations.push_back(6);
 
+    const read_id_t expected_number_of_reads                              = 2;
+    const position_in_read_t expected_number_of_basepairs_in_longest_read = 9;
+
     test_function(filename,
                   0,
                   2,
@@ -2249,7 +2287,8 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_filtering)
                   expected_first_occurrence_of_representations,
                   expected_read_id_to_read_name,
                   expected_read_id_to_read_length,
-                  2,
+                  expected_number_of_reads,
+                  expected_number_of_basepairs_in_longest_read,
                   filtering_parameter);
 }
 

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -1261,7 +1261,7 @@ void test_function(const std::string& filename,
                    const std::vector<std::uint32_t>& expected_first_occurrence_of_representations,
                    const std::vector<std::string>& expected_read_id_to_read_name,
                    const std::vector<std::uint32_t>& expected_read_id_to_read_length,
-                   const std::uint64_t expected_number_of_reads,
+                   const read_id_t expected_number_of_reads,
                    const double filtering_parameter = 1.0)
 {
     std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename);

--- a/cudamapper/tests/Test_CudamapperMinimizer.cpp
+++ b/cudamapper/tests/Test_CudamapperMinimizer.cpp
@@ -76,10 +76,10 @@ void test_function(const std::uint64_t number_of_reads_to_add,
 
 TEST(TestCudamappperMinimizer, GATT_4_1)
 {
-    const read_id_t number_of_reads_to_add = 1;
-    const std::uint64_t minimizer_size         = 4;
-    const std::uint64_t window_size            = 1;
-    const std::uint64_t read_id_of_first_read  = 0;
+    const read_id_t number_of_reads_to_add    = 1;
+    const std::uint64_t minimizer_size        = 4;
+    const std::uint64_t window_size           = 1;
+    const std::uint64_t read_id_of_first_read = 0;
 
     const std::vector<char> merged_basepairs_h{'G', 'A', 'T', 'T'};
 
@@ -137,10 +137,10 @@ TEST(TestCudamappperMinimizer, GATT_2_3)
     // back end minimizers
     // TT: 00 2 R 0
 
-    const read_id_t number_of_reads_to_add = 1;
-    const std::uint64_t minimizer_size         = 2;
-    const std::uint64_t window_size            = 3;
-    const std::uint64_t read_id_of_first_read  = 0;
+    const read_id_t number_of_reads_to_add    = 1;
+    const std::uint64_t minimizer_size        = 2;
+    const std::uint64_t window_size           = 3;
+    const std::uint64_t read_id_of_first_read = 0;
 
     const std::vector<char> merged_basepairs_h{'G', 'A', 'T', 'T'};
 
@@ -219,10 +219,10 @@ TEST(TestCudamappperMinimizer, CCCATACC_2_7)
     // ACC    : 01 5 F 0
     // CC     : 11 6 F 0
 
-    const read_id_t number_of_reads_to_add = 1;
-    const std::uint64_t minimizer_size         = 2;
-    const std::uint64_t window_size            = 7;
-    const std::uint64_t read_id_of_first_read  = 0;
+    const read_id_t number_of_reads_to_add    = 1;
+    const std::uint64_t minimizer_size        = 2;
+    const std::uint64_t window_size           = 7;
+    const std::uint64_t read_id_of_first_read = 0;
 
     const std::vector<char> merged_basepairs_h{'C', 'C', 'C', 'A', 'T', 'A', 'C', 'C'};
 
@@ -322,10 +322,10 @@ TEST(TestCudamappperMinimizer, CATCAAG_AAGCTA_3_2)
 
     // all minimizers: (032,0,R,0), (031,1,F,0), (100,3,F,0), (002,4,F,0), (002,0,F,1), (021,2,R,1), (130,3,F,1)
 
-    const read_id_t number_of_reads_to_add = 2;
-    const std::uint64_t minimizer_size         = 3;
-    const std::uint64_t window_size            = 2;
-    const std::uint64_t read_id_of_first_read  = 0;
+    const read_id_t number_of_reads_to_add    = 2;
+    const std::uint64_t minimizer_size        = 3;
+    const std::uint64_t window_size           = 2;
+    const std::uint64_t read_id_of_first_read = 0;
 
     const std::vector<char> merged_basepairs_h{'C', 'A', 'T', 'C', 'A', 'A', 'G', 'A', 'A', 'G', 'C', 'T', 'A'};
 
@@ -433,10 +433,10 @@ TEST(TestCudamappperMinimizer, CATCAAG_AAGCTA_3_2_read_id_offset_5)
 
     // all minimizers: (032,0,R,0), (031,1,F,0), (100,3,F,0), (002,4,F,0), (002,0,F,1), (021,2,R,1), (130,3,F,1)
 
-    const read_id_t number_of_reads_to_add = 2;
-    const std::uint64_t minimizer_size         = 3;
-    const std::uint64_t window_size            = 2;
-    const std::uint64_t read_id_of_first_read  = 5;
+    const read_id_t number_of_reads_to_add    = 2;
+    const std::uint64_t minimizer_size        = 3;
+    const std::uint64_t window_size           = 2;
+    const std::uint64_t read_id_of_first_read = 5;
 
     const std::vector<char> merged_basepairs_h{'C', 'A', 'T', 'C', 'A', 'A', 'G', 'A', 'A', 'G', 'C', 'T', 'A'};
 

--- a/cudamapper/tests/Test_CudamapperMinimizer.cpp
+++ b/cudamapper/tests/Test_CudamapperMinimizer.cpp
@@ -76,7 +76,7 @@ void test_function(const std::uint64_t number_of_reads_to_add,
 
 TEST(TestCudamappperMinimizer, GATT_4_1)
 {
-    const std::uint64_t number_of_reads_to_add = 1;
+    const read_id_t number_of_reads_to_add = 1;
     const std::uint64_t minimizer_size         = 4;
     const std::uint64_t window_size            = 1;
     const std::uint64_t read_id_of_first_read  = 0;
@@ -137,7 +137,7 @@ TEST(TestCudamappperMinimizer, GATT_2_3)
     // back end minimizers
     // TT: 00 2 R 0
 
-    const std::uint64_t number_of_reads_to_add = 1;
+    const read_id_t number_of_reads_to_add = 1;
     const std::uint64_t minimizer_size         = 2;
     const std::uint64_t window_size            = 3;
     const std::uint64_t read_id_of_first_read  = 0;
@@ -219,7 +219,7 @@ TEST(TestCudamappperMinimizer, CCCATACC_2_7)
     // ACC    : 01 5 F 0
     // CC     : 11 6 F 0
 
-    const std::uint64_t number_of_reads_to_add = 1;
+    const read_id_t number_of_reads_to_add = 1;
     const std::uint64_t minimizer_size         = 2;
     const std::uint64_t window_size            = 7;
     const std::uint64_t read_id_of_first_read  = 0;
@@ -322,7 +322,7 @@ TEST(TestCudamappperMinimizer, CATCAAG_AAGCTA_3_2)
 
     // all minimizers: (032,0,R,0), (031,1,F,0), (100,3,F,0), (002,4,F,0), (002,0,F,1), (021,2,R,1), (130,3,F,1)
 
-    const std::uint64_t number_of_reads_to_add = 2;
+    const read_id_t number_of_reads_to_add = 2;
     const std::uint64_t minimizer_size         = 3;
     const std::uint64_t window_size            = 2;
     const std::uint64_t read_id_of_first_read  = 0;
@@ -433,7 +433,7 @@ TEST(TestCudamappperMinimizer, CATCAAG_AAGCTA_3_2_read_id_offset_5)
 
     // all minimizers: (032,0,R,0), (031,1,F,0), (100,3,F,0), (002,4,F,0), (002,0,F,1), (021,2,R,1), (130,3,F,1)
 
-    const std::uint64_t number_of_reads_to_add = 2;
+    const read_id_t number_of_reads_to_add = 2;
     const std::uint64_t minimizer_size         = 3;
     const std::uint64_t window_size            = 2;
     const std::uint64_t read_id_of_first_read  = 5;


### PR DESCRIPTION
Implemented `Index::number_of_basepairs_in_longest_read()` which returns the length of the longest read in that index.
Also switched return type of `Index::number_of_reads` from `std::uint64_t` to `read_id_t`.

These methods will be needed in a future PR for Anchor sorting

See #265 