### PR TITLE
[cudamapper] Cached allocator to manage device memory allocations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ option(cga_optimize_for_native_cpu "Build with march=native" ON)
 option(spoa_accurate "Run cudapoa code in mode that matches spoa" OFF)
 option(cga_enable_cudapoa_nw_print "Enable verbose prints within cudapoa NW kernel" OFF)
 option(cga_profiling "Compile a binary for profiling with NVTX markers." OFF)
+option(cga_enable_allocator "Enable caching allocator." ON)
 option(cga_generate_docs "Generate Doxygen documentation" ON)
 
 # Must be included before others for options value validation

--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
 #pragma once
 #include <cub/util_allocator.cuh>
 

--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -1,0 +1,76 @@
+#pragma once
+#include <cub/util_allocator.cuh>
+
+namespace claragenomics
+{
+
+/** Default cudaMalloc/cudaFree based device allocator */
+class deviceAllocator
+{
+public:
+    virtual void* allocate(std::size_t n, cudaStream_t)
+    {
+        void* ptr = 0;
+        CGA_CU_CHECK_ERR(cudaMalloc(&ptr, n));
+        return ptr;
+    }
+    virtual void deallocate(void* p, std::size_t, cudaStream_t)
+    {
+        cudaError_t status = cudaFree(p);
+        if (cudaSuccess != status)
+        {
+            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
+        }
+    }
+
+    virtual ~deviceAllocator() {}
+};
+
+/** Default cudaHostMalloc/cudaFreeHost based host allocator */
+class hostAllocator
+{
+public:
+    virtual void* allocate(std::size_t n, cudaStream_t)
+    {
+        void* ptr = 0;
+        CGA_CU_CHECK_ERR(cudaMallocHost(&ptr, n));
+        return ptr;
+    }
+    virtual void deallocate(void* p, std::size_t, cudaStream_t)
+    {
+        cudaError_t status = cudaFreeHost(p);
+        if (cudaSuccess != status)
+        {
+            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
+        }
+    }
+
+    virtual ~hostAllocator() {}
+};
+
+class cachingDeviceAllocator : public deviceAllocator
+{
+public:
+    cachingDeviceAllocator()
+        : _allocator(8, 3, cub::CachingDeviceAllocator::INVALID_BIN, cub::CachingDeviceAllocator::INVALID_SIZE, false, false)
+    {
+    }
+
+    virtual void* allocate(std::size_t n, cudaStream_t stream)
+    {
+        void* ptr = 0;
+        _allocator.DeviceAllocate(&ptr, n, stream);
+        return ptr;
+    }
+
+    virtual void deallocate(void* p, std::size_t, cudaStream_t)
+    {
+        // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
+        _allocator.DeviceFree(p);
+    }
+
+private:
+    cub::CachingDeviceAllocator _allocator;
+};
+
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -20,9 +20,19 @@ namespace claragenomics
 class DeviceAllocator
 {
 public:
+    /// @brief Asynchronously allocates device memory.
+    ////       An implementation of this need to return a allocation of n bytes properly aligned
+    ///        on the configured device.
+    /// @param n      number of bytes to allocate
+    /// @param stream CUDA stream to be associated with this method.
+    /// @returns a pointer to a n byte properly aligned device buffer on the configured device.
     virtual void* allocate(std::size_t n, cudaStream_t stream) = 0;
 
-    virtual void deallocate(void* p, std::size_t, cudaStream_t stream) = 0;
+    /// @brief Asynchronously deallocates device memory.
+    /// @param p      pointer to the buffer to deallocate
+    /// @param n      size of the buffer to deallocate in bytes
+    /// @param stream CUDA stream to be associated with this method.
+    virtual void deallocate(void* p, std::size_t n, cudaStream_t stream) = 0;
 };
 
 /**
@@ -31,9 +41,19 @@ public:
 class HostAllocator
 {
 public:
+    /// @brief Asynchronously allocates host memory.
+    ////       An implementation of this need to return a allocation of n bytes properly aligned
+    ///        on the host.
+    /// @param n       number of bytes to allocate
+    /// @param stream  CUDA stream to be associated with this method.
+    /// @returns a pointer to a n byte properly aligned host buffer.
     virtual void* allocate(std::size_t n, cudaStream_t stream) = 0;
 
-    virtual void deallocate(void* p, std::size_t, cudaStream_t strean) = 0;
+    /// @brief Asynchronously deallocates host memory.
+    /// @param p      pointer to the buffer to deallocate
+    /// @param n      size of the buffer to deallocate in bytes
+    /// @param stream CUDA stream to be associated with this method.
+    virtual void deallocate(void* p, std::size_t n, cudaStream_t stream) = 0;
 };
 
 /**
@@ -64,6 +84,8 @@ public:
 class CachingDeviceAllocator : public DeviceAllocator
 {
 public:
+    /// @brief This constructor intializes and constructs cub's CachingDeviceAllocator
+    /// @param max_cached_bytes Maximum aggregate cached bytes per device (default is 1GB)
     CachingDeviceAllocator(size_t max_cached_bytes = 1e9)
         : _allocator(2, 10, cub::CachingDeviceAllocator::INVALID_BIN, max_cached_bytes, false, false)
     {

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -1,52 +1,9 @@
 #pragma once
 #include <claragenomics/utils/cudautils.hpp>
+#include <claragenomics/utils/allocator.hpp>
 
 namespace claragenomics
 {
-
-/** Default cudaMalloc/cudaFree based device allocator */
-class deviceAllocator
-{
-public:
-    virtual void* allocate(std::size_t n, cudaStream_t)
-    {
-        void* ptr = 0;
-        CGA_CU_CHECK_ERR(cudaMalloc(&ptr, n));
-        return ptr;
-    }
-    virtual void deallocate(void* p, std::size_t, cudaStream_t)
-    {
-        cudaError_t status = cudaFree(p);
-        if (cudaSuccess != status)
-        {
-            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
-        }
-    }
-
-    virtual ~deviceAllocator() {}
-};
-
-/** Default cudaHostMalloc/cudaFreeHost based host allocator */
-class hostAllocator
-{
-public:
-    virtual void* allocate(std::size_t n, cudaStream_t)
-    {
-        void* ptr = 0;
-        CGA_CU_CHECK_ERR(cudaMallocHost(&ptr, n));
-        return ptr;
-    }
-    virtual void deallocate(void* p, std::size_t, cudaStream_t)
-    {
-        cudaError_t status = cudaFreeHost(p);
-        if (cudaSuccess != status)
-        {
-            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
-        }
-    }
-
-    virtual ~hostAllocator() {}
-};
 
 template <typename T, typename Allocator>
 class buffer
@@ -56,8 +13,6 @@ public:
     using size_type      = std::size_t;
     using iterator       = value_type*;
     using const_iterator = const value_type*;
-
-    //buffer() = delete;
 
     buffer(const buffer& other) = delete;
 

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -9,6 +9,7 @@
  */
 #pragma once
 
+#include <memory>
 #include <claragenomics/utils/cudautils.hpp>
 
 namespace claragenomics

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -36,6 +36,7 @@ public:
         , _stream(stream)
         , _allocator(allocator)
     {
+        static_assert(std::is_trivial<value_type>::value, "buffer only supports trivial types and classes.");
         assert(_size >= 0);
         if (_capacity > 0)
         {
@@ -48,6 +49,7 @@ public:
     explicit buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
         : buffer(0, allocator, stream)
     {
+        static_assert(std::is_trivial<value_type>::value, "buffer only supports trivial types and classes.");
     }
 
     // move constructor

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -10,7 +10,6 @@
 
 #pragma once
 #include <claragenomics/utils/cudautils.hpp>
-#include <claragenomics/utils/allocator.hpp>
 
 namespace claragenomics
 {
@@ -46,8 +45,7 @@ public:
         }
     }
 
-    // Should this be removed and force it to use allocator for a common interface?
-    buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
+    explicit buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
         : buffer(0, allocator, stream)
     {
     }
@@ -123,10 +121,15 @@ public:
         reserve(new_capacity, _stream);
     }
 
-    void resize(const size_type new_size, cudaStream_t stream = 0)
+    void resize(const size_type new_size, cudaStream_t stream)
     {
         reserve(new_size, stream);
         _size = new_size;
+    }
+
+    void resize(const size_type new_size)
+    {
+        resize(new_size, _stream);
     }
 
     void swap(buffer& v)
@@ -138,7 +141,7 @@ public:
         std::swap(_allocator, v._allocator);
     }
 
-    void shrink_to_fit(cudaStream_t stream = 0)
+    void shrink_to_fit(cudaStream_t stream)
     {
         set_stream(stream);
         if (_capacity > _size)
@@ -158,8 +161,12 @@ public:
             _capacity = _size;
         }
     }
+    void shrink_to_fit()
+    {
+        shrink_to_fit(_stream);
+    }
 
-    void free(cudaStream_t stream = 0)
+    void free(cudaStream_t stream)
     {
         set_stream(stream);
         if (nullptr != _data)
@@ -169,6 +176,10 @@ public:
         _data     = nullptr;
         _capacity = 0;
         _size     = 0;
+    }
+    void free()
+    {
+        free(_stream);
     }
 
 private:

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -7,26 +7,41 @@
  * distribution of this software and related documentation without an express
  * license agreement from NVIDIA CORPORATION is strictly prohibited.
  */
-
 #pragma once
+
 #include <claragenomics/utils/cudautils.hpp>
 
 namespace claragenomics
 {
 
+/// @brief Container for a single object of type `T` in host or device memory.
+///        `T` must be trivially copyable.
+/// @tparam T The object's type
+/// @tparam Allocator The allocator's type
 template <typename T, typename Allocator>
 class buffer
 {
 public:
-    using value_type     = T;
-    using size_type      = std::ptrdiff_t;
-    using iterator       = value_type*;
+    /// data type for the \b buffer allocation [supports only trivially copyable types].
+    using value_type = T;
+
+    /// signed integer type for defining size, count, and the global offsets.
+    using size_type = std::ptrdiff_t;
+
+    /// a pointer type to iterate/refer the \p buffer elements.
+    using iterator = value_type*;
+
+    /// a const pointer type to iterate/refer the \p buffer elements.
     using const_iterator = const value_type*;
 
     buffer(const buffer& other) = delete;
 
     buffer& operator=(const buffer& other) = delete;
 
+    /// @brief This constructor creates \p buffer with the given size.
+    /// @param n The number of elements to initially create.
+    /// @param allocator The allocator to use by this buffer.
+    /// @param stream The CUDA stream to be associated with this allocation. Default is stream 0.
     explicit buffer(size_type n                          = 0,
                     std::shared_ptr<Allocator> allocator = std::make_shared<Allocator>(),
                     cudaStream_t stream                  = 0)
@@ -46,13 +61,17 @@ public:
         }
     }
 
+    /// @brief This constructor creates an empty \p buffer.
+    /// @param allocator The allocator to use by this buffer.
+    /// @param stream The CUDA stream to be associated with this allocation. Default is stream 0.
     explicit buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
         : buffer(0, allocator, stream)
     {
         static_assert(std::is_trivially_copyable<value_type>::value, "buffer only supports trivially copyable types and classes, because destructors will not be called.");
     }
 
-    // move constructor
+    /// @brief Move constructor moves from another \p buffer.
+    /// @param r The bufer to move.
     buffer(buffer&& r)
         : _size(std::exchange(r._size, 0))
         , _capacity(std::exchange(r._size, 0))
@@ -62,7 +81,8 @@ public:
     {
     }
 
-    // move assignment operator
+    /// @brief Move assign operator moves from another \p buffer.
+    /// @param r The buffer to move.
     buffer& operator=(buffer&& r)
     {
         _size      = std::exchange(r._size, 0);
@@ -73,6 +93,7 @@ public:
         return *this;
     }
 
+    /// @brief This destructor releases the buffer allocation, returning it to the allocator.
     ~buffer()
     {
         if (nullptr != _data)
@@ -81,22 +102,41 @@ public:
         }
     }
 
+    /// @brief This method returns a pointer to this buffer's first element.
+    /// @return A pointer to the first element of this buffer.
     value_type* data() { return _data; }
 
+    /// @brief This method returns a const_pointer to this buffer's first element.
+    /// @return A const pointer to the first element of this buffer.
     const value_type* data() const { return _data; }
 
+    /// @brief This method returns the number of elements in this buffer.
     size_type size() const { return _size; }
 
+    /// @brief This method resizes this buffer to 0.
     void clear() { _size = 0; }
 
+    /// @brief This method returns an iterator pointing to the beginning of this buffer.
     iterator begin() { return _data; }
 
+    /// @brief This method returns an const_iterator pointing to the beginning of this buffer.
     const_iterator begin() const { return _data; }
 
+    /// @brief This method returns a iterator pointing to one element past the last of this buffer.
+    /// @return begin() + size().
     iterator end() { return _data + _size; }
 
+    /// @brief This method returns a const_iterator pointing to one element past the last of this buffer.
+    /// @return begin() + size().
     const_iterator end() const { return _data + _size; }
 
+    /// @brief This method reserves memory for the specified number of elements.
+    ///        If new_capacity is less than or equal to _capacity, this call has no effect.
+    ///        Otherwise, this method is a request for allocation of additional memory. If
+    ///        the request is successful, then _capacity is equal to the new_capacity;
+    ///        otherwise, _capacity is unchanged. In either case, size() is unchanged.
+    /// @param new_capacity The number of elements to reserve.
+    /// @param stream The CUDA stream to be associated with this method.
     void reserve(const size_type new_capacity, cudaStream_t stream)
     {
         assert(new_capacity >= 0);
@@ -118,22 +158,34 @@ public:
             _capacity = new_capacity;
         }
     }
+
+    /// @brief This method reserves memory for the specified number of elements. It is implicitly
+    ///        associated with the CUDA stream provided during the buffer creation.
+    /// @param new_capacity The number of elements to reserve.
     void reserve(const size_type new_capacity)
     {
         reserve(new_capacity, _stream);
     }
 
+    /// @brief This method resizes this buffer to the specified number of elements.
+    /// @param new_size Number of elements this buffer should contain.
+    /// @param stream The CUDA stream to be associated with this method.
     void resize(const size_type new_size, cudaStream_t stream)
     {
         reserve(new_size, stream);
         _size = new_size;
     }
 
+    /// @brief This method resizes this buffer to the specified number of elements. It is
+    ///        implicitly associated with the CUDA stream provided during the buffer creation.
+    /// @param new_size Number of elements this buffer should contain.
     void resize(const size_type new_size)
     {
         resize(new_size, _stream);
     }
 
+    /// @brief This method swaps the contents of this buffer with another buffer.
+    /// @param v The buffer with which to swap.
     void swap(buffer& v)
     {
         std::swap(_data, v._data);
@@ -143,6 +195,8 @@ public:
         std::swap(_allocator, v._allocator);
     }
 
+    /// @brief This method shrinks the capacity of this buffer to exactly fit its elements.
+    /// @param stream The CUDA stream to be associated with this method.
     void shrink_to_fit(cudaStream_t stream)
     {
         set_stream(stream);
@@ -163,11 +217,16 @@ public:
             _capacity = _size;
         }
     }
+
+    /// @brief This method shrinks the capacity of this buffer to exactly fit its elements.
+    ///        It is implicitly associated with the CUDA stream provided during the buffer creation.
     void shrink_to_fit()
     {
         shrink_to_fit(_stream);
     }
 
+    /// @brief This method releases the memory allocated by this buffer, returning it to the allocator.
+    /// @param stream The CUDA stream to be associated with this method.
     void free(cudaStream_t stream)
     {
         set_stream(stream);
@@ -179,6 +238,9 @@ public:
         _capacity = 0;
         _size     = 0;
     }
+
+    /// @brief This method releases the memory allocated by this buffer, returning it to the allocator.
+    ///        It is implicitly associated with the CUDA stream provided during the buffer creation.
     void free()
     {
         free(_stream);
@@ -205,6 +267,7 @@ private:
     }
 };
 
+/// @brief This method swaps the contents of buffer a with b.
 template <typename T, typename Allocator>
 void swap(buffer<T, Allocator>& a,
           buffer<T, Allocator>& b)

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -36,7 +36,7 @@ public:
         , _stream(stream)
         , _allocator(allocator)
     {
-        static_assert(std::is_trivial<value_type>::value, "buffer only supports trivial types and classes.");
+        static_assert(std::is_trivially_copyable<value_type>::value, "buffer only supports trivially copyable types and classes, because destructors will not be called.");
         assert(_size >= 0);
         if (_capacity > 0)
         {
@@ -49,7 +49,7 @@ public:
     explicit buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
         : buffer(0, allocator, stream)
     {
-        static_assert(std::is_trivial<value_type>::value, "buffer only supports trivial types and classes.");
+        static_assert(std::is_trivially_copyable<value_type>::value, "buffer only supports trivially copyable types and classes, because destructors will not be called.");
     }
 
     // move constructor

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -1,0 +1,213 @@
+#pragma once
+#include <claragenomics/utils/cudautils.hpp>
+
+namespace claragenomics
+{
+
+/** Default cudaMalloc/cudaFree based device allocator */
+class deviceAllocator
+{
+public:
+    virtual void* allocate(std::size_t n, cudaStream_t)
+    {
+        void* ptr = 0;
+        CGA_CU_CHECK_ERR(cudaMalloc(&ptr, n));
+        return ptr;
+    }
+    virtual void deallocate(void* p, std::size_t, cudaStream_t)
+    {
+        cudaError_t status = cudaFree(p);
+        if (cudaSuccess != status)
+        {
+            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
+        }
+    }
+
+    virtual ~deviceAllocator() {}
+};
+
+/** Default cudaHostMalloc/cudaFreeHost based host allocator */
+class hostAllocator
+{
+public:
+    virtual void* allocate(std::size_t n, cudaStream_t)
+    {
+        void* ptr = 0;
+        CGA_CU_CHECK_ERR(cudaMallocHost(&ptr, n));
+        return ptr;
+    }
+    virtual void deallocate(void* p, std::size_t, cudaStream_t)
+    {
+        cudaError_t status = cudaFreeHost(p);
+        if (cudaSuccess != status)
+        {
+            // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
+        }
+    }
+
+    virtual ~hostAllocator() {}
+};
+
+template <typename T, typename Allocator>
+class buffer
+{
+public:
+    using value_type     = T;
+    using size_type      = std::size_t;
+    using iterator       = value_type*;
+    using const_iterator = const value_type*;
+
+    //buffer() = delete;
+
+    buffer(const buffer& other) = delete;
+
+    buffer& operator=(const buffer& other) = delete;
+
+    buffer(size_type n                          = 0,
+           std::shared_ptr<Allocator> allocator = std::make_shared<Allocator>(),
+           cudaStream_t stream                  = 0)
+        : _size(n)
+        , _capacity(n)
+        , _data(nullptr)
+        , _stream(stream)
+        , _allocator(allocator)
+    {
+        if (_capacity > 0)
+        {
+            _data = static_cast<value_type*>(
+                _allocator->allocate(_capacity * sizeof(value_type), _stream));
+            CGA_CU_CHECK_ERR(cudaStreamSynchronize(_stream));
+        }
+    }
+
+    // Should this be removed and force it to use allocator for a common interface?
+    buffer(std::shared_ptr<Allocator> allocator, cudaStream_t stream = 0)
+        : buffer(0, allocator, stream)
+    {
+    }
+
+    // move constructor
+    buffer(buffer&& r)
+        : _size(std::exchange(r._size, 0))
+        , _capacity(std::exchange(r._size, 0))
+        , _data(std::exchange(r._data, nullptr))
+        , _stream(std::exchange(r._stream, cudaStream_t(0)))
+        , _allocator(std::exchange(r._allocator, std::shared_ptr<Allocator>(nullptr)))
+    {
+    }
+
+    ~buffer()
+    {
+        if (nullptr != _data)
+        {
+            _allocator->deallocate(_data, _capacity * sizeof(value_type), _stream);
+        }
+    }
+
+    value_type* data() { return _data; }
+
+    const value_type* data() const { return _data; }
+
+    size_type size() const { return _size; }
+
+    void clear() { _size = 0; }
+
+    iterator begin() { return _data; }
+
+    const_iterator begin() const { return _data; }
+
+    iterator end() { return _data + _size; }
+
+    const_iterator end() const { return _data + _size; }
+
+    void reserve(const size_type new_capacity, cudaStream_t stream = 0)
+    {
+        set_stream(stream);
+        if (new_capacity > _capacity)
+        {
+            value_type* new_data = static_cast<value_type*>(
+                _allocator->allocate(new_capacity * sizeof(value_type), _stream));
+            if (_size > 0)
+            {
+                CGA_CU_CHECK_ERR(cudaMemcpyAsync(new_data, _data, _size * sizeof(value_type),
+                                                 cudaMemcpyDefault, _stream));
+            }
+            if (nullptr != _data)
+            {
+                _allocator->deallocate(_data, _capacity * sizeof(value_type), _stream);
+            }
+            _data     = new_data;
+            _capacity = new_capacity;
+        }
+    }
+
+    void resize(const size_type new_size, cudaStream_t stream = 0)
+    {
+        reserve(new_size, stream);
+        _size = new_size;
+    }
+
+    void swap(buffer& v)
+    {
+        std::swap(_data, v._data);
+        std::swap(_size, v._size);
+        std::swap(_capacity, v._capacity);
+        std::swap(_stream, v._stream);
+        std::swap(_allocator, v._allocator);
+    }
+
+    void shrink_to_fit(cudaStream_t stream = 0)
+    {
+        set_stream(stream);
+        if (_capacity > _size)
+        {
+            value_type* new_data = static_cast<value_type*>(
+                _allocator->allocate(_size * sizeof(value_type), _stream));
+            if (_size > 0)
+            {
+                CGA_CU_CHECK_ERR(cudaMemcpyAsync(new_data, _data, _size * sizeof(value_type),
+                                                 cudaMemcpyDefault, _stream));
+            }
+            if (nullptr != _data)
+            {
+                _allocator->deallocate(_data, _capacity * sizeof(value_type), _stream);
+            }
+            _data     = new_data;
+            _capacity = _size;
+        }
+    }
+
+    void free(cudaStream_t stream = 0)
+    {
+        set_stream(stream);
+        if (nullptr != _data)
+        {
+            _allocator->deallocate(_data, _capacity * sizeof(value_type), _stream);
+        }
+        _data     = nullptr;
+        _capacity = 0;
+        _size     = 0;
+    }
+
+private:
+    value_type* _data = nullptr;
+    size_type _size;
+    size_type _capacity;
+    cudaStream_t _stream;
+    std::shared_ptr<Allocator> _allocator;
+
+    void set_stream(cudaStream_t stream)
+    {
+        if (_stream != stream)
+        {
+            cudaEvent_t event;
+            CGA_CU_CHECK_ERR(cudaEventCreateWithFlags(&event, cudaEventDisableTiming));
+            CGA_CU_CHECK_ERR(cudaEventRecord(event, _stream));
+            CGA_CU_CHECK_ERR(cudaStreamWaitEvent(stream, event, 0));
+            _stream = stream;
+            CGA_CU_CHECK_ERR(cudaEventDestroy(event));
+        }
+    }
+};
+
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
 #pragma once
 #include <claragenomics/utils/cudautils.hpp>
 #include <claragenomics/utils/allocator.hpp>

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -89,6 +89,7 @@ __host__ __device__ __forceinline__
     return (value + boundary) & ~(boundary - 1);
 }
 
+/// Copy and return value from a device memory location with implicit synchronization
 template <typename Type>
 Type get_value_from_device(const Type* d_ptr, cudaStream_t stream = 0)
 {
@@ -98,24 +99,28 @@ Type get_value_from_device(const Type* d_ptr, cudaStream_t stream = 0)
     return val;
 }
 
+/// Copies value from 'src' address to 'dst' address asynchronously.
 template <typename Type>
 void set_device_value_async(Type* dst, const Type* src, cudaStream_t stream)
 {
     CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, sizeof(Type), cudaMemcpyDefault, stream));
 }
 
+/// Copies the value 'src' to 'dst' address.
 template <typename Type>
 void set_device_value(Type* dst, const Type& src)
 {
     CGA_CU_CHECK_ERR(cudaMemcpy(dst, &src, sizeof(Type), cudaMemcpyDefault));
 }
 
+/// Copies elements from the range [src, src + n) to the range [dst, dst + n) asynchronously.
 template <typename Type>
 void device_copy_n(const Type* src, size_t n, Type* dst, cudaStream_t stream)
 {
     CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, n * sizeof(Type), cudaMemcpyDefault, stream));
 }
 
+/// Copies elements from the range [src, src + n) to the range [dst, dst + n).
 template <typename Type>
 void device_copy_n(const Type* src, size_t n, Type* dst)
 {

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -99,7 +99,7 @@ Type get_value_from_device(const Type* d_ptr, cudaStream_t stream = 0)
 }
 
 template <typename Type>
-void set_device_value_async(const Type* dst, const Type* src, cudaStream_t stream)
+void set_device_value_async(Type* dst, const Type* src, cudaStream_t stream)
 {
     CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, sizeof(Type), cudaMemcpyDefault, stream));
 }

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -90,15 +90,30 @@ __host__ __device__ __forceinline__
 }
 
 template <typename Type>
-void copy(Type* dst, const Type* src, size_t len, cudaStream_t stream)
+Type get_value_from_device(const Type* d_ptr, cudaStream_t stream = 0)
 {
-    CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, len * sizeof(Type), cudaMemcpyDefault, stream));
+    Type val;
+    CGA_CU_CHECK_ERR(cudaMemcpyAsync(&val, d_ptr, sizeof(Type), cudaMemcpyDeviceToHost, stream));
+    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
+    return val;
 }
 
 template <typename Type>
-void copy(Type* dst, const Type* src, size_t len)
+void set_device_value_async(const Type* dst, const Type* src, cudaStream_t stream)
 {
-    CGA_CU_CHECK_ERR(cudaMemcpy(dst, src, len * sizeof(Type), cudaMemcpyDefault));
+    CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, sizeof(Type), cudaMemcpyDefault, stream));
+}
+
+template <typename Type>
+void set_device_value(Type* dst, const Type* src)
+{
+    CGA_CU_CHECK_ERR(cudaMemcpy(dst, src, sizeof(Type), cudaMemcpyDefault));
+}
+
+template <typename Type>
+void device_copy_n(const Type* src, size_t n, Type* dst, cudaStream_t stream)
+{
+    CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, n * sizeof(Type), cudaMemcpyDefault, stream));
 }
 
 #ifdef CGA_PROFILING

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -105,9 +105,9 @@ void set_device_value_async(Type* dst, const Type* src, cudaStream_t stream)
 }
 
 template <typename Type>
-void set_device_value(Type* dst, const Type* src)
+void set_device_value(Type* dst, const Type& src)
 {
-    CGA_CU_CHECK_ERR(cudaMemcpy(dst, src, sizeof(Type), cudaMemcpyDefault));
+    CGA_CU_CHECK_ERR(cudaMemcpy(dst, &src, sizeof(Type), cudaMemcpyDefault));
 }
 
 template <typename Type>

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -89,6 +89,18 @@ __host__ __device__ __forceinline__
     return (value + boundary) & ~(boundary - 1);
 }
 
+template <typename Type>
+void copy(Type* dst, const Type* src, size_t len, cudaStream_t stream)
+{
+    CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, len * sizeof(Type), cudaMemcpyDefault, stream));
+}
+
+template <typename Type>
+void copy(Type* dst, const Type* src, size_t len)
+{
+    CGA_CU_CHECK_ERR(cudaMemcpy(dst, src, len * sizeof(Type), cudaMemcpyDefault));
+}
+
 #ifdef CGA_PROFILING
 /// \ingroup cudautils
 /// \def CGA_NVTX_RANGE

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -116,6 +116,12 @@ void device_copy_n(const Type* src, size_t n, Type* dst, cudaStream_t stream)
     CGA_CU_CHECK_ERR(cudaMemcpyAsync(dst, src, n * sizeof(Type), cudaMemcpyDefault, stream));
 }
 
+template <typename Type>
+void device_copy_n(const Type* src, size_t n, Type* dst)
+{
+    CGA_CU_CHECK_ERR(cudaMemcpy(dst, src, n * sizeof(Type), cudaMemcpyDefault));
+}
+
 #ifdef CGA_PROFILING
 /// \ingroup cudautils
 /// \def CGA_NVTX_RANGE

--- a/common/utils/include/claragenomics/utils/device_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/device_buffer.hpp
@@ -1,0 +1,17 @@
+#pragma once
+#include <claragenomics/utils/buffer.hpp>
+
+namespace claragenomics
+{
+
+template <typename T>
+using device_buffer = buffer<T, deviceAllocator>;
+
+template <typename T, typename Allocator>
+void swap(buffer<T, Allocator>& a,
+          buffer<T, Allocator>& b)
+{
+    a.swap(b);
+}
+
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/device_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/device_buffer.hpp
@@ -10,6 +10,7 @@
 
 #pragma once
 #include <claragenomics/utils/buffer.hpp>
+#include <claragenomics/utils/allocator.hpp>
 
 namespace claragenomics
 {

--- a/common/utils/include/claragenomics/utils/device_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/device_buffer.hpp
@@ -15,13 +15,6 @@ namespace claragenomics
 {
 
 template <typename T>
-using device_buffer = buffer<T, deviceAllocator>;
-
-template <typename T, typename Allocator>
-void swap(buffer<T, Allocator>& a,
-          buffer<T, Allocator>& b)
-{
-    a.swap(b);
-}
+using device_buffer = buffer<T, DeviceAllocator>;
 
 } // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/device_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/device_buffer.hpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
 #pragma once
 #include <claragenomics/utils/buffer.hpp>
 

--- a/common/utils/include/claragenomics/utils/host_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/host_buffer.hpp
@@ -1,0 +1,10 @@
+#pragma once
+#include <claragenomics/utils/buffer.hpp>
+
+namespace claragenomics
+{
+
+template <typename T>
+using host_buffer = buffer<T, hostAllocator>;
+
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/host_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/host_buffer.hpp
@@ -15,6 +15,6 @@ namespace claragenomics
 {
 
 template <typename T>
-using host_buffer = buffer<T, hostAllocator>;
+using host_buffer = buffer<T, HostAllocator>;
 
 } // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/host_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/host_buffer.hpp
@@ -10,6 +10,7 @@
 
 #pragma once
 #include <claragenomics/utils/buffer.hpp>
+#include <claragenomics/utils/allocator.hpp>
 
 namespace claragenomics
 {

--- a/common/utils/include/claragenomics/utils/host_buffer.hpp
+++ b/common/utils/include/claragenomics/utils/host_buffer.hpp
@@ -1,3 +1,13 @@
+/*
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * NVIDIA CORPORATION and its licensors retain all intellectual property
+ * and proprietary rights in and to this software, related documentation
+ * and any modifications thereto.  Any use, reproduction, disclosure or
+ * distribution of this software and related documentation without an express
+ * license agreement from NVIDIA CORPORATION is strictly prohibited.
+ */
+
 #pragma once
 #include <claragenomics/utils/buffer.hpp>
 

--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 
 cuda_add_library(minimizer
         src/minimizer.cu)
-target_include_directories(minimizer PUBLIC include)
+target_include_directories(minimizer PUBLIC include ${CUB_DIR})
 target_link_libraries(minimizer logging pthread utils)
 target_compile_options(minimizer PRIVATE -Werror)
 
@@ -32,13 +32,13 @@ cuda_add_library(index_gpu
         src/index.cu
         src/index_gpu.cu
         src/minimizer.cu)
-target_include_directories(index_gpu PUBLIC include)
+target_include_directories(index_gpu PUBLIC include ${CUB_DIR})
 target_link_libraries(index_gpu logging minimizer pthread utils cgaio)
 target_compile_options(index_gpu PRIVATE -Werror)
 
 cuda_add_library(matcher_gpu
         src/matcher_gpu.cu)
-target_include_directories(matcher_gpu PUBLIC include)
+target_include_directories(matcher_gpu PUBLIC include ${CUB_DIR})
 target_link_libraries(matcher_gpu logging utils cgaio)
 target_compile_options(matcher_gpu PRIVATE -Werror)
 
@@ -54,12 +54,17 @@ target_compile_options(overlapper_triggerred PRIVATE -Werror)
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+
 cuda_add_executable(cudamapper
         src/cudamapper.cpp
         src/main.cu
         src/matcher.cu
         src/overlapper.cpp
 )
+
+if(cga_enable_allocator)
+    target_compile_definitions(cudamapper PUBLIC CGA_ENABLE_ALLOCATOR)
+endif()
 
 target_compile_options(cudamapper PRIVATE -Werror)
 

--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -54,7 +54,6 @@ target_compile_options(overlapper_triggerred PRIVATE -Werror)
 
 add_doxygen_source_dir(${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-
 cuda_add_executable(cudamapper
         src/cudamapper.cpp
         src/main.cu

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -17,7 +17,7 @@
 #include <claragenomics/cudamapper/types.hpp>
 #include <claragenomics/io/fasta_parser.hpp>
 
-#include <thrust/device_vector.h>
+#include <claragenomics/utils/device_buffer.hpp>
 
 namespace claragenomics
 {
@@ -36,19 +36,19 @@ public:
 
     /// \brief returns an array of representations of sketch elements
     /// \return an array of representations of sketch elements
-    virtual const thrust::device_vector<representation_t>& representations() const = 0;
+    virtual const device_buffer<representation_t>& representations() const = 0;
 
     /// \brief returns an array of reads ids for sketch elements
     /// \return an array of reads ids for sketch elements
-    virtual const thrust::device_vector<read_id_t>& read_ids() const = 0;
+    virtual const device_buffer<read_id_t>& read_ids() const = 0;
 
     /// \brief returns an array of starting positions of sketch elements in their reads
     /// \return an array of starting positions of sketch elements in their reads
-    virtual const thrust::device_vector<position_in_read_t>& positions_in_reads() const = 0;
+    virtual const device_buffer<position_in_read_t>& positions_in_reads() const = 0;
 
     /// \brief returns an array of directions in which sketch elements were read
     /// \return an array of directions in which sketch elements were read
-    virtual const thrust::device_vector<SketchElement::DirectionOfRepresentation>& directions_of_reads() const = 0;
+    virtual const device_buffer<SketchElement::DirectionOfRepresentation>& directions_of_reads() const = 0;
 
     /// \brief returns read name of read with the given read_id
     /// \param read_id
@@ -57,11 +57,11 @@ public:
 
     /// \brief returns an array where each representation is recorder only once, sorted by representation
     /// \return an array where each representation is recorder only once, sorted by representation
-    virtual const thrust::device_vector<representation_t>& unique_representations() const = 0;
+    virtual const device_buffer<representation_t>& unique_representations() const = 0;
 
     /// \brief returns first occurrence of corresponding representation from unique_representations() in data arrays
     /// \return first occurrence of corresponding representation from unique_representations() in data arrays
-    virtual const thrust::device_vector<std::uint32_t>& first_occurrence_of_representations() const = 0;
+    virtual const device_buffer<std::uint32_t>& first_occurrence_of_representations() const = 0;
 
     /// \brief returns read length for the read with the gived read_id
     /// \param read_id

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -93,7 +93,7 @@ public:
     /// \param filtering_parameter - filter out all representations for which number_of_sketch_elements_with_that_representation/total_skech_elements >= filtering_parameter, filtering_parameter == 1.0 disables filtering
     /// \return instance of Index
     static std::unique_ptr<Index>
-    create_index(std::shared_ptr<deviceAllocator> allocator,
+    create_index(std::shared_ptr<DeviceAllocator> allocator,
                  const io::FastaParser& parser,
                  const read_id_t first_read_id,
                  const read_id_t past_the_last_read_id,

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -84,6 +84,7 @@ public:
     }
 
     /// \brief generates a mapping of (k,w)-kmer-representation to all of its occurrences for one or more sequences
+    /// \param allocator The device memory allocator to use for temporary buffer allocations
     /// \param parser parser for the whole input file (part that goes into this index is determined by first_read_id and past_the_last_read_id)
     /// \param first_read_id read_id of the first read to the included in this index
     /// \param past_the_last_read_id read_id+1 of the last read to be included in this index

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -93,7 +93,8 @@ public:
     /// \param filtering_parameter - filter out all representations for which number_of_sketch_elements_with_that_representation/total_skech_elements >= filtering_parameter, filtering_parameter == 1.0 disables filtering
     /// \return instance of Index
     static std::unique_ptr<Index>
-    create_index(const io::FastaParser& parser,
+    create_index(std::shared_ptr<deviceAllocator> allocator,
+                 const io::FastaParser& parser,
                  const read_id_t first_read_id,
                  const read_id_t past_the_last_read_id,
                  const std::uint64_t kmer_size,

--- a/cudamapper/include/claragenomics/cudamapper/matcher.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/matcher.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <thrust/device_vector.h>
 #include <claragenomics/cudamapper/index.hpp>
+#include <claragenomics/utils/device_buffer.hpp>
 
 namespace claragenomics
 {
@@ -31,7 +32,7 @@ public:
 
     /// \brief returns anchors
     /// \return anchors
-    virtual thrust::device_vector<Anchor>& anchors() = 0;
+    virtual device_buffer<Anchor>& anchors() = 0;
 
     /// \brief Creates a Matcher object
     /// \param query_index

--- a/cudamapper/include/claragenomics/cudamapper/matcher.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/matcher.hpp
@@ -38,7 +38,8 @@ public:
     /// \param query_index
     /// \param target_index
     /// \return matcher
-    static std::unique_ptr<Matcher> create_matcher(const Index& query_index,
+    static std::unique_ptr<Matcher> create_matcher(std::shared_ptr<deviceAllocator> allocator,
+						   const Index& query_index,
                                                    const Index& target_index);
 };
 

--- a/cudamapper/include/claragenomics/cudamapper/matcher.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/matcher.hpp
@@ -35,6 +35,7 @@ public:
     virtual device_buffer<Anchor>& anchors() = 0;
 
     /// \brief Creates a Matcher object
+    /// \param allocator The device memory allocator to use for buffer allocations
     /// \param query_index
     /// \param target_index
     /// \return matcher

--- a/cudamapper/include/claragenomics/cudamapper/matcher.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/matcher.hpp
@@ -38,8 +38,8 @@ public:
     /// \param query_index
     /// \param target_index
     /// \return matcher
-    static std::unique_ptr<Matcher> create_matcher(std::shared_ptr<deviceAllocator> allocator,
-						   const Index& query_index,
+    static std::unique_ptr<Matcher> create_matcher(std::shared_ptr<DeviceAllocator> allocator,
+                                                   const Index& query_index,
                                                    const Index& target_index);
 };
 

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -36,7 +36,7 @@ public:
     /// \param index_query representation index for reads
     /// \param index_target
     virtual void get_overlaps(std::vector<Overlap>& overlaps,
-                              thrust::device_vector<Anchor>& anchors,
+                              device_buffer<Anchor>& anchors,
                               const Index& index_query,
                               const Index& index_target) = 0;
 

--- a/cudamapper/include/claragenomics/cudamapper/types.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/types.hpp
@@ -79,21 +79,21 @@ typedef struct Overlap
     /// end position in the target
     position_in_read_t target_end_position_in_read_;
     /// query read name (e.g from FASTA)
-    char* query_read_name_;
+    char* query_read_name_ = 0;
     /// target read name (e.g from FASTA)
-    char* target_read_name_;
+    char* target_read_name_ = 0;
     /// Relative strand: Forward ("+") or Reverse("-")
     RelativeStrand relative_strand;
     /// Number of residues (e.g anchors) between the two reads
-    std::uint32_t num_residues_;
+    std::uint32_t num_residues_ = 0;
     /// Length of query sequence
-    std::uint32_t query_length_;
+    std::uint32_t query_length_ = 0;
     /// Length of target sequence
-    std::uint32_t target_length_;
+    std::uint32_t target_length_ = 0;
     /// Whether the overlap is considered valid by the generating overlapper
-    bool overlap_complete;
+    bool overlap_complete = false;
     /// CIGAR string for alignment of mapped section.
-    char* cigar_;
+    char* cigar_ = 0;
 } Overlap;
 
 } // namespace cudamapper

--- a/cudamapper/include/claragenomics/cudamapper/types.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/types.hpp
@@ -50,16 +50,6 @@ enum class RelativeStrand : unsigned char
 /// Anchor is a pair of two sketch elements with the same sketch element representation from different reads
 struct Anchor
 {
-/// empty default constructor to prevent costly instantiations of all elements when initializing containers
-#ifdef __CUDACC__
-    __host__ __device__ Anchor()
-    {
-    }
-#else
-    Anchor()
-    {
-    }
-#endif
     /// read ID of query
     read_id_t query_read_id_;
     /// read ID of target
@@ -89,21 +79,21 @@ typedef struct Overlap
     /// end position in the target
     position_in_read_t target_end_position_in_read_;
     /// query read name (e.g from FASTA)
-    char* query_read_name_ = 0;
+    char* query_read_name_;
     /// target read name (e.g from FASTA)
-    char* target_read_name_ = 0;
+    char* target_read_name_;
     /// Relative strand: Forward ("+") or Reverse("-")
     RelativeStrand relative_strand;
     /// Number of residues (e.g anchors) between the two reads
-    std::uint32_t num_residues_ = 0;
+    std::uint32_t num_residues_;
     /// Length of query sequence
-    std::uint32_t query_length_ = 0;
+    std::uint32_t query_length_;
     /// Length of target sequence
-    std::uint32_t target_length_ = 0;
+    std::uint32_t target_length_;
     /// Whether the overlap is considered valid by the generating overlapper
-    bool overlap_complete = false;
+    bool overlap_complete;
     /// CIGAR string for alignment of mapped section.
-    char* cigar_ = 0;
+    char* cigar_;
 } Overlap;
 
 } // namespace cudamapper

--- a/cudamapper/src/index.cu
+++ b/cudamapper/src/index.cu
@@ -18,7 +18,8 @@ namespace claragenomics
 namespace cudamapper
 {
 
-std::unique_ptr<Index> Index::create_index(const io::FastaParser& parser,
+std::unique_ptr<Index> Index::create_index(std::shared_ptr<deviceAllocator> allocator,
+                                           const io::FastaParser& parser,
                                            const read_id_t first_read_id,
                                            const read_id_t past_the_last_read_id,
                                            const std::uint64_t kmer_size,
@@ -27,7 +28,8 @@ std::unique_ptr<Index> Index::create_index(const io::FastaParser& parser,
                                            const double filtering_parameter)
 {
     CGA_NVTX_RANGE(profiler, "create_index");
-    return std::make_unique<IndexGPU<Minimizer>>(parser,
+    return std::make_unique<IndexGPU<Minimizer>>(allocator,
+                                                 parser,
                                                  first_read_id,
                                                  past_the_last_read_id,
                                                  kmer_size,

--- a/cudamapper/src/index.cu
+++ b/cudamapper/src/index.cu
@@ -18,7 +18,7 @@ namespace claragenomics
 namespace cudamapper
 {
 
-std::unique_ptr<Index> Index::create_index(std::shared_ptr<deviceAllocator> allocator,
+std::unique_ptr<Index> Index::create_index(std::shared_ptr<DeviceAllocator> allocator,
                                            const io::FastaParser& parser,
                                            const read_id_t first_read_id,
                                            const read_id_t past_the_last_read_id,

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -19,9 +19,9 @@ namespace details
 {
 namespace index_gpu
 {
-void find_first_occurrences_of_representations(thrust::device_vector<representation_t>& unique_representations_d,
-                                               thrust::device_vector<std::uint32_t>& first_occurrence_index_d,
-                                               const thrust::device_vector<representation_t>& input_representations_d)
+void find_first_occurrences_of_representations(device_buffer<representation_t>& unique_representations_d,
+                                               device_buffer<std::uint32_t>& first_occurrence_index_d,
+                                               const device_buffer<representation_t>& input_representations_d)
 {
     // TODO: Currently maximum number of thread blocks is 2^31-1. This means we support representations of up to (2^31-1) * number_of_threads
     // With 256 that's (2^31-1)*2^8 ~= 2^39. If representation is 4-byte (we expect it to be 4 or 8) that's 2^39*2^2 = 2^41 = 2TB. We don't expect to hit this limit any time soon
@@ -36,38 +36,44 @@ void find_first_occurrences_of_representations(thrust::device_vector<representat
     // gives
     // 1  1  1  1  2  2  2  2  2  2  3  3  3  4  4  4  4  4  5  5  5
     // meaning all elements with the same representation have the same value and those values are sorted in increasing order starting from 1
-    thrust::device_vector<std::uint64_t> representation_index_mask_d(input_representations_d.size());
+    device_buffer<std::uint64_t> representation_index_mask_d(input_representations_d.size());
     {
         const std::int64_t number_of_representations               = get_size(input_representations_d);
-        const representation_t* const input_representations_d_data = input_representations_d.data().get();
-        thrust::transform_inclusive_scan(thrust::device,
-                                         thrust::make_counting_iterator(std::int64_t(0)),
-                                         thrust::make_counting_iterator(number_of_representations),
-                                         representation_index_mask_d.begin(),
-                                         [input_representations_d_data] __device__(std::int64_t idx) -> std::uint64_t {
-                                             if (idx == 0)
-                                                 return 1;
-                                             return (input_representations_d_data[idx - 1] != input_representations_d_data[idx] ? 1 : 0);
-                                         },
-                                         thrust::plus<std::uint64_t>());
+        const representation_t* const input_representations_d_data = input_representations_d.data();
+        thrust::transform_inclusive_scan(
+            thrust::device,
+            thrust::make_counting_iterator(std::int64_t(0)),
+            thrust::make_counting_iterator(number_of_representations),
+            representation_index_mask_d.begin(),
+            [input_representations_d_data] __device__(std::int64_t idx) -> std::uint64_t {
+                if (idx == 0)
+                    return 1;
+                return (input_representations_d_data[idx - 1] != input_representations_d_data[idx] ? 1 : 0);
+            },
+            thrust::plus<std::uint64_t>());
     }
 
-    const std::uint64_t number_of_unique_representations = representation_index_mask_d.back(); // D2H copy
+    //const std::uint64_t number_of_unique_representations = representation_index_mask_d.back(); // D2H copy
+    std::uint64_t number_of_unique_representations = 0;
+    cudautils::copy(&number_of_unique_representations, representation_index_mask_d.end() - 1, 1); // D2H copy
 
     first_occurrence_index_d.resize(number_of_unique_representations + 1); // <- +1 for the additional element
-    if (first_occurrence_index_d.capacity() > first_occurrence_index_d.size())
-        first_occurrence_index_d.shrink_to_fit();
+    //if (first_occurrence_index_d.capacity() > first_occurrence_index_d.size())
+    first_occurrence_index_d.shrink_to_fit();
     unique_representations_d.resize(number_of_unique_representations);
-    if (unique_representations_d.capacity() > unique_representations_d.size())
-        unique_representations_d.shrink_to_fit();
+    //if (unique_representations_d.capacity() > unique_representations_d.size())
+    unique_representations_d.shrink_to_fit();
 
-    find_first_occurrences_of_representations_kernel<<<number_of_blocks, number_of_threads>>>(representation_index_mask_d.data().get(),
-                                                                                              input_representations_d.data().get(),
+    find_first_occurrences_of_representations_kernel<<<number_of_blocks, number_of_threads>>>(representation_index_mask_d.data(),
+                                                                                              input_representations_d.data(),
                                                                                               representation_index_mask_d.size(),
-                                                                                              first_occurrence_index_d.data().get(),
-                                                                                              unique_representations_d.data().get());
+                                                                                              first_occurrence_index_d.data(),
+                                                                                              unique_representations_d.data());
     // last element is the total number of elements in representations array
-    first_occurrence_index_d.back() = input_representations_d.size(); // H2D copy
+
+    std::uint32_t input_representations_size = input_representations_d.size();
+    cudautils::copy(first_occurrence_index_d.end() - 1, &input_representations_size, 1); // H2D copy
+    //first_occurrence_index_d.back() = input_representations_d.size(); // H2D copy
 }
 
 __global__ void find_first_occurrences_of_representations_kernel(const std::uint64_t* const representation_index_mask_d,

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -19,7 +19,7 @@ namespace details
 {
 namespace index_gpu
 {
-void find_first_occurrences_of_representations(std::shared_ptr<deviceAllocator> allocator,
+void find_first_occurrences_of_representations(std::shared_ptr<DeviceAllocator> allocator,
                                                device_buffer<representation_t>& unique_representations_d,
                                                device_buffer<std::uint32_t>& first_occurrence_index_d,
                                                const device_buffer<representation_t>& input_representations_d)
@@ -54,9 +54,7 @@ void find_first_occurrences_of_representations(std::shared_ptr<deviceAllocator> 
             thrust::plus<std::uint64_t>());
     }
 
-    //const std::uint64_t number_of_unique_representations = representation_index_mask_d.back(); // D2H copy
-    std::uint64_t number_of_unique_representations = 0;
-    cudautils::copy(&number_of_unique_representations, representation_index_mask_d.end() - 1, 1); // D2H copy
+    const std::uint64_t number_of_unique_representations = cudautils::get_value_from_device(representation_index_mask_d.end() - 1); // D2H copy
 
     first_occurrence_index_d.resize(number_of_unique_representations + 1); // <- +1 for the additional element
     //if (first_occurrence_index_d.capacity() > first_occurrence_index_d.size())
@@ -73,8 +71,7 @@ void find_first_occurrences_of_representations(std::shared_ptr<deviceAllocator> 
     // last element is the total number of elements in representations array
 
     std::uint32_t input_representations_size = input_representations_d.size();
-    cudautils::copy(first_occurrence_index_d.end() - 1, &input_representations_size, 1); // H2D copy
-    //first_occurrence_index_d.back() = input_representations_d.size(); // H2D copy
+    cudautils::set_device_value(first_occurrence_index_d.end() - 1, &input_representations_size); // H2D copy
 }
 
 __global__ void find_first_occurrences_of_representations_kernel(const std::uint64_t* const representation_index_mask_d,

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -57,10 +57,8 @@ void find_first_occurrences_of_representations(std::shared_ptr<DeviceAllocator> 
     const std::uint64_t number_of_unique_representations = cudautils::get_value_from_device(representation_index_mask_d.end() - 1); // D2H copy
 
     first_occurrence_index_d.resize(number_of_unique_representations + 1); // <- +1 for the additional element
-    //if (first_occurrence_index_d.capacity() > first_occurrence_index_d.size())
     first_occurrence_index_d.shrink_to_fit();
     unique_representations_d.resize(number_of_unique_representations);
-    //if (unique_representations_d.capacity() > unique_representations_d.size())
     unique_representations_d.shrink_to_fit();
 
     find_first_occurrences_of_representations_kernel<<<number_of_blocks, number_of_threads>>>(representation_index_mask_d.data(),
@@ -71,7 +69,7 @@ void find_first_occurrences_of_representations(std::shared_ptr<DeviceAllocator> 
     // last element is the total number of elements in representations array
 
     std::uint32_t input_representations_size = input_representations_d.size();
-    cudautils::set_device_value(first_occurrence_index_d.end() - 1, &input_representations_size); // H2D copy
+    cudautils::set_device_value(first_occurrence_index_d.end() - 1, input_representations_size); // H2D copy
 }
 
 __global__ void find_first_occurrences_of_representations_kernel(const std::uint64_t* const representation_index_mask_d,

--- a/cudamapper/src/index_gpu.cu
+++ b/cudamapper/src/index_gpu.cu
@@ -19,7 +19,8 @@ namespace details
 {
 namespace index_gpu
 {
-void find_first_occurrences_of_representations(device_buffer<representation_t>& unique_representations_d,
+void find_first_occurrences_of_representations(std::shared_ptr<deviceAllocator> allocator,
+                                               device_buffer<representation_t>& unique_representations_d,
                                                device_buffer<std::uint32_t>& first_occurrence_index_d,
                                                const device_buffer<representation_t>& input_representations_d)
 {
@@ -36,7 +37,7 @@ void find_first_occurrences_of_representations(device_buffer<representation_t>& 
     // gives
     // 1  1  1  1  2  2  2  2  2  2  3  3  3  4  4  4  4  4  5  5  5
     // meaning all elements with the same representation have the same value and those values are sorted in increasing order starting from 1
-    device_buffer<std::uint64_t> representation_index_mask_d(input_representations_d.size());
+    device_buffer<std::uint64_t> representation_index_mask_d(input_representations_d.size(), allocator);
     {
         const std::int64_t number_of_representations               = get_size(input_representations_d);
         const representation_t* const input_representations_d_data = input_representations_d.data();

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -25,7 +25,7 @@
 #include <claragenomics/cudamapper/types.hpp>
 #include <claragenomics/io/fasta_parser.hpp>
 #include <claragenomics/logging/logging.hpp>
-#include <claragenomics/utils/device_buffer.cuh>
+#include <claragenomics/utils/device_buffer.hpp>
 #include <claragenomics/utils/mathutils.hpp>
 #include <claragenomics/utils/signed_integer_utils.hpp>
 
@@ -70,27 +70,27 @@ public:
 
     /// \brief returns an array of representations of sketch elements
     /// \return an array of representations of sketch elements
-    const thrust::device_vector<representation_t>& representations() const override;
+    const device_buffer<representation_t>& representations() const override;
 
     /// \brief returns an array of reads ids for sketch elements
     /// \return an array of reads ids for sketch elements
-    const thrust::device_vector<read_id_t>& read_ids() const override;
+    const device_buffer<read_id_t>& read_ids() const override;
 
     /// \brief returns an array of starting positions of sketch elements in their reads
     /// \return an array of starting positions of sketch elements in their reads
-    const thrust::device_vector<position_in_read_t>& positions_in_reads() const override;
+    const device_buffer<position_in_read_t>& positions_in_reads() const override;
 
     /// \brief returns an array of directions in which sketch elements were read
     /// \return an array of directions in which sketch elements were read
-    const thrust::device_vector<typename SketchElementImpl::DirectionOfRepresentation>& directions_of_reads() const override;
+    const device_buffer<typename SketchElementImpl::DirectionOfRepresentation>& directions_of_reads() const override;
 
     /// \brief returns an array where each representation is recorder only once, sorted by representation
     /// \return an array where each representation is recorder only once, sorted by representation
-    const thrust::device_vector<representation_t>& unique_representations() const override;
+    const device_buffer<representation_t>& unique_representations() const override;
 
     /// \brief returns first occurrence of corresponding representation from unique_representations() in data arrays, plus one more element with the total number of sketch elements
     /// \return first occurrence of corresponding representation from unique_representations() in data arrays, plus one more element with the total number of sketch elements
-    const thrust::device_vector<std::uint32_t>& first_occurrence_of_representations() const override;
+    const device_buffer<std::uint32_t>& first_occurrence_of_representations() const override;
 
     /// \brief returns read name of read with the given read_id
     /// \param read_id
@@ -118,13 +118,13 @@ private:
                         const bool hash_representations,
                         const double filtering_parameter);
 
-    thrust::device_vector<representation_t> representations_d_;
-    thrust::device_vector<read_id_t> read_ids_d_;
-    thrust::device_vector<position_in_read_t> positions_in_reads_d_;
-    thrust::device_vector<typename SketchElementImpl::DirectionOfRepresentation> directions_of_reads_d_;
+    device_buffer<representation_t> representations_d_;
+    device_buffer<read_id_t> read_ids_d_;
+    device_buffer<position_in_read_t> positions_in_reads_d_;
+    device_buffer<typename SketchElementImpl::DirectionOfRepresentation> directions_of_reads_d_;
 
-    thrust::device_vector<representation_t> unique_representations_d_;
-    thrust::device_vector<std::uint32_t> first_occurrence_of_representations_d_;
+    device_buffer<representation_t> unique_representations_d_;
+    device_buffer<std::uint32_t> first_occurrence_of_representations_d_;
 
     std::vector<std::string> read_id_to_read_name_;
     std::vector<std::uint32_t> read_id_to_read_length_;
@@ -159,9 +159,9 @@ namespace index_gpu
 /// \param unique_representations_d empty on input, contains one value of each representation on the output
 /// \param first_occurrence_index_d empty on input, index of first occurrence of each representation and additional elemnt on the output
 /// \param input_representations_d an array of representaton where representations with the same value stand next to each other
-void find_first_occurrences_of_representations(thrust::device_vector<representation_t>& unique_representations_d,
-                                               thrust::device_vector<std::uint32_t>& first_occurrence_index_d,
-                                               const thrust::device_vector<representation_t>& input_representations_d);
+void find_first_occurrences_of_representations(device_buffer<representation_t>& unique_representations_d,
+                                               device_buffer<std::uint32_t>& first_occurrence_index_d,
+                                               const device_buffer<representation_t>& input_representations_d);
 
 /// \brief Helper kernel for find_first_occurrences_of_representations
 ///
@@ -372,19 +372,21 @@ __global__ void compress_data_arrays_after_filtering_kernel(const std::uint64_t 
 /// \tparam DirectionOfRepresentation any implementation of SketchElementImpl::SketchElementImpl::DirectionOfRepresentation
 template <typename DirectionOfRepresentation>
 void filter_out_most_common_representations(const double filtering_parameter,
-                                            thrust::device_vector<representation_t>& representations_d,
-                                            thrust::device_vector<read_id_t>& read_ids_d,
-                                            thrust::device_vector<position_in_read_t>& positions_in_reads_d,
-                                            thrust::device_vector<DirectionOfRepresentation>& directions_of_representations_d,
-                                            thrust::device_vector<representation_t>& unique_representations_d,
-                                            thrust::device_vector<std::uint32_t>& first_occurrence_of_representations_d)
+                                            device_buffer<representation_t>& representations_d,
+                                            device_buffer<read_id_t>& read_ids_d,
+                                            device_buffer<position_in_read_t>& positions_in_reads_d,
+                                            device_buffer<DirectionOfRepresentation>& directions_of_representations_d,
+                                            device_buffer<representation_t>& unique_representations_d,
+                                            device_buffer<std::uint32_t>& first_occurrence_of_representations_d)
 {
     // *** find the number of sketch_elements for every representation ***
     // 0  2  4  8 14 17 20 <- first_occurrence_of_representations_d (before filtering)
     // 2  2  4  6  3  3  0 <- number_of_sketch_elements_with_each_representation_d (with additional 0 at the end)
 
-    thrust::device_vector<std::uint32_t> number_of_sketch_elements_with_each_representation_d(first_occurrence_of_representations_d.size());
-    number_of_sketch_elements_with_each_representation_d.back() = 0; // H2D
+    std::uint32_t zero = 0;
+    device_buffer<std::uint32_t> number_of_sketch_elements_with_each_representation_d(first_occurrence_of_representations_d.size());
+    cudautils::copy(number_of_sketch_elements_with_each_representation_d.end() - 1, &zero, 1); // H2D
+    //number_of_sketch_elements_with_each_representation_d.back() = 0; // H2D
 
     // thrust::adjacent_difference saves a[i]-a[i-1] to a[i]. As first_occurrence_of_representations_d starts with 0
     // we actually want to save a[i]-a[i-1] to a[i-j] and have the last (aditional) element of number_of_sketch_elements_with_each_representation_d set to 0
@@ -392,7 +394,8 @@ void filter_out_most_common_representations(const double filtering_parameter,
                                 std::next(std::begin(first_occurrence_of_representations_d)),
                                 std::end(first_occurrence_of_representations_d),
                                 std::begin(number_of_sketch_elements_with_each_representation_d));
-    number_of_sketch_elements_with_each_representation_d.back() = 0; // H2D
+    cudautils::copy(number_of_sketch_elements_with_each_representation_d.end() - 1, &zero, 1); // H2D
+    //number_of_sketch_elements_with_each_representation_d.back() = 0; // H2D
 
     // *** find filtering threshold ***
     const std::size_t total_sketch_elements = representations_d.size();
@@ -404,19 +407,20 @@ void filter_out_most_common_representations(const double filtering_parameter,
     // 2  2  4  6  3  3  0 <- number_of_sketch_elements_with_each_representation_d (before filtering)
     // 2  2  0  0  3  3  0 <- number_of_sketch_elements_with_each_representation_d (after filtering)
 
-    thrust::replace_if(thrust::device,
-                       std::begin(number_of_sketch_elements_with_each_representation_d),
-                       std::prev(std::end(number_of_sketch_elements_with_each_representation_d)), // don't process the last element, it should remain 0
-                       [filtering_threshold] __device__(const std::uint32_t val) {
-                           return val >= filtering_threshold;
-                       },
-                       0);
+    thrust::replace_if(
+        thrust::device,
+        std::begin(number_of_sketch_elements_with_each_representation_d),
+        std::prev(std::end(number_of_sketch_elements_with_each_representation_d)), // don't process the last element, it should remain 0
+        [filtering_threshold] __device__(const std::uint32_t val) {
+            return val >= filtering_threshold;
+        },
+        0);
 
     // *** perform exclusive sum to find the starting position of each representation after filtering ***
     // If a representation is to be filtered out its value is the same to the value to its left
     // 2  2  0  0  3  3  0 <- number_of_sketch_elements_with_each_representation_d (after filtering)
     // 0  2  4  4  4  7 10 <- first_occurrence_of_representation_after_filtering_d
-    thrust::device_vector<std::uint32_t> first_occurrence_of_representation_after_filtering_d(number_of_sketch_elements_with_each_representation_d.size());
+    device_buffer<std::uint32_t> first_occurrence_of_representation_after_filtering_d(number_of_sketch_elements_with_each_representation_d.size());
     thrust::exclusive_scan(thrust::device,
                            std::begin(number_of_sketch_elements_with_each_representation_d),
                            std::end(number_of_sketch_elements_with_each_representation_d),
@@ -431,23 +435,24 @@ void filter_out_most_common_representations(const double filtering_parameter,
     // 0  1  2  2  2  3  4 <- unique_representation_index_after_filtering_d
 
     const std::int64_t number_of_unique_representations = get_size(unique_representations_d);
-    thrust::device_vector<std::uint32_t> unique_representation_index_after_filtering_d(number_of_unique_representations + 1);
+    device_buffer<std::uint32_t> unique_representation_index_after_filtering_d(number_of_unique_representations + 1);
 
     {
         // direct pointer needed as device_vector::operator[] is a host function and it would be called from device lambda
-        const std::uint32_t* const number_of_sketch_elements_with_each_representation_d_ptr = number_of_sketch_elements_with_each_representation_d.data().get();
-        thrust::transform_exclusive_scan(thrust::device,
-                                         thrust::make_counting_iterator(std::int64_t(0)),
-                                         thrust::make_counting_iterator(number_of_unique_representations + 1),
-                                         std::begin(unique_representation_index_after_filtering_d),
-                                         [number_of_sketch_elements_with_each_representation_d_ptr, number_of_unique_representations] __device__(const std::int64_t unique_representation_index) -> std::uint32_t {
-                                             if (unique_representation_index < number_of_unique_representations)
-                                                 return (0 == number_of_sketch_elements_with_each_representation_d_ptr[unique_representation_index] ? 0 : 1);
-                                             else // the additional element at the end
-                                                 return 0;
-                                         },
-                                         0,
-                                         thrust::plus<std::uint64_t>());
+        const std::uint32_t* const number_of_sketch_elements_with_each_representation_d_ptr = number_of_sketch_elements_with_each_representation_d.data();
+        thrust::transform_exclusive_scan(
+            thrust::device,
+            thrust::make_counting_iterator(std::int64_t(0)),
+            thrust::make_counting_iterator(number_of_unique_representations + 1),
+            std::begin(unique_representation_index_after_filtering_d),
+            [number_of_sketch_elements_with_each_representation_d_ptr, number_of_unique_representations] __device__(const std::int64_t unique_representation_index) -> std::uint32_t {
+                if (unique_representation_index < number_of_unique_representations)
+                    return (0 == number_of_sketch_elements_with_each_representation_d_ptr[unique_representation_index] ? 0 : 1);
+                else // the additional element at the end
+                    return 0;
+            },
+            0,
+            thrust::plus<std::uint64_t>());
     }
 
     // *** remove filtered out elements (compress) from unique_representations_d and first_occurrence_of_representations_d ***
@@ -457,21 +462,23 @@ void filter_out_most_common_representations(const double filtering_parameter,
     // 0  2  4  4  4  7 10 <- first_occurrence_of_representation_after_filtering_d
     // 0  2  4  7 10       <- first_occurrence_of_representations_after_compression_d
 
-    const std::uint32_t number_of_unique_representations_after_compression = unique_representation_index_after_filtering_d.back(); // D2H
+    //const std::uint32_t number_of_unique_representations_after_compression = unique_representation_index_after_filtering_d.back(); // D2H
+    std::uint32_t number_of_unique_representations_after_compression = 0;
+    cudautils::copy(&number_of_unique_representations_after_compression, unique_representation_index_after_filtering_d.end() - 1, 1); // D2H
 
-    thrust::device_vector<representation_t> unique_representations_after_compression_d(number_of_unique_representations_after_compression);
-    thrust::device_vector<std::uint32_t> first_occurrence_of_representations_after_compression_d(number_of_unique_representations_after_compression + 1);
+    device_buffer<representation_t> unique_representations_after_compression_d(number_of_unique_representations_after_compression);
+    device_buffer<std::uint32_t> first_occurrence_of_representations_after_compression_d(number_of_unique_representations_after_compression + 1);
 
     std::int32_t number_of_threads = 128;
     std::int32_t number_of_blocks  = ceiling_divide<std::int64_t>(first_occurrence_of_representations_d.size(),
                                                                  number_of_threads);
 
     compress_unique_representations_after_filtering_kernel<<<number_of_blocks, number_of_threads>>>(unique_representations_d.size(),
-                                                                                                    unique_representations_d.data().get(),
-                                                                                                    first_occurrence_of_representation_after_filtering_d.data().get(),
-                                                                                                    unique_representation_index_after_filtering_d.data().get(),
-                                                                                                    unique_representations_after_compression_d.data().get(),
-                                                                                                    first_occurrence_of_representations_after_compression_d.data().get());
+                                                                                                    unique_representations_d.data(),
+                                                                                                    first_occurrence_of_representation_after_filtering_d.data(),
+                                                                                                    unique_representation_index_after_filtering_d.data(),
+                                                                                                    unique_representations_after_compression_d.data(),
+                                                                                                    first_occurrence_of_representations_after_compression_d.data());
 
     // *** remove filtered out elements (compress) from other data arrays ***
 
@@ -484,35 +491,38 @@ void filter_out_most_common_representations(const double filtering_parameter,
     // 0  0  1  1  4  7  3  7  8  9 <- positions_in_reads_after_filtering_d
     // F  F  F  F  F  R  R  F  F  F <- directions_of_reads_after_filtering_d
 
-    std::uint32_t number_of_sketch_elements_after_compression = first_occurrence_of_representations_after_compression_d.back(); // D2H
-    thrust::device_vector<representation_t> representations_after_compression_d(number_of_sketch_elements_after_compression);
-    thrust::device_vector<read_id_t> read_ids_after_compression_d(number_of_sketch_elements_after_compression);
-    thrust::device_vector<position_in_read_t> positions_in_reads_after_compression_d(number_of_sketch_elements_after_compression);
-    thrust::device_vector<DirectionOfRepresentation> directions_of_representations_after_compression_d(number_of_sketch_elements_after_compression);
+    //std::uint32_t number_of_sketch_elements_after_compression = first_occurrence_of_representations_after_compression_d.back(); // D2H
+    std::uint32_t number_of_sketch_elements_after_compression = 0;
+    cudautils::copy(&number_of_sketch_elements_after_compression, first_occurrence_of_representations_after_compression_d.end() - 1, 1); // D2H
+
+    device_buffer<representation_t> representations_after_compression_d(number_of_sketch_elements_after_compression);
+    device_buffer<read_id_t> read_ids_after_compression_d(number_of_sketch_elements_after_compression);
+    device_buffer<position_in_read_t> positions_in_reads_after_compression_d(number_of_sketch_elements_after_compression);
+    device_buffer<DirectionOfRepresentation> directions_of_representations_after_compression_d(number_of_sketch_elements_after_compression);
 
     number_of_threads = 32;
     number_of_blocks  = unique_representations_d.size();
     compress_data_arrays_after_filtering_kernel<<<number_of_blocks, number_of_threads>>>(unique_representations_d.size(),
-                                                                                         number_of_sketch_elements_with_each_representation_d.data().get(),
-                                                                                         first_occurrence_of_representations_d.data().get(),
-                                                                                         first_occurrence_of_representations_after_compression_d.data().get(),
-                                                                                         unique_representation_index_after_filtering_d.data().get(),
-                                                                                         representations_d.data().get(),
-                                                                                         read_ids_d.data().get(),
-                                                                                         positions_in_reads_d.data().get(),
-                                                                                         directions_of_representations_d.data().get(),
-                                                                                         representations_after_compression_d.data().get(),
-                                                                                         read_ids_after_compression_d.data().get(),
-                                                                                         positions_in_reads_after_compression_d.data().get(),
-                                                                                         directions_of_representations_after_compression_d.data().get());
+                                                                                         number_of_sketch_elements_with_each_representation_d.data(),
+                                                                                         first_occurrence_of_representations_d.data(),
+                                                                                         first_occurrence_of_representations_after_compression_d.data(),
+                                                                                         unique_representation_index_after_filtering_d.data(),
+                                                                                         representations_d.data(),
+                                                                                         read_ids_d.data(),
+                                                                                         positions_in_reads_d.data(),
+                                                                                         directions_of_representations_d.data(),
+                                                                                         representations_after_compression_d.data(),
+                                                                                         read_ids_after_compression_d.data(),
+                                                                                         positions_in_reads_after_compression_d.data(),
+                                                                                         directions_of_representations_after_compression_d.data());
 
     // *** swap vectors with the input arrays ***
-    std::swap(unique_representations_d, unique_representations_after_compression_d);
-    std::swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
-    std::swap(representations_d, representations_after_compression_d);
-    std::swap(read_ids_d, read_ids_after_compression_d);
-    std::swap(positions_in_reads_d, positions_in_reads_after_compression_d);
-    std::swap(directions_of_representations_d, directions_of_representations_after_compression_d);
+    claragenomics::swap(unique_representations_d, unique_representations_after_compression_d);
+    claragenomics::swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
+    claragenomics::swap(representations_d, representations_after_compression_d);
+    claragenomics::swap(read_ids_d, read_ids_after_compression_d);
+    claragenomics::swap(positions_in_reads_d, positions_in_reads_after_compression_d);
+    claragenomics::swap(directions_of_representations_d, directions_of_representations_after_compression_d);
 }
 
 } // namespace index_gpu
@@ -540,37 +550,37 @@ IndexGPU<SketchElementImpl>::IndexGPU(const io::FastaParser& parser,
 }
 
 template <typename SketchElementImpl>
-const thrust::device_vector<representation_t>& IndexGPU<SketchElementImpl>::representations() const
+const device_buffer<representation_t>& IndexGPU<SketchElementImpl>::representations() const
 {
     return representations_d_;
 };
 
 template <typename SketchElementImpl>
-const thrust::device_vector<read_id_t>& IndexGPU<SketchElementImpl>::read_ids() const
+const device_buffer<read_id_t>& IndexGPU<SketchElementImpl>::read_ids() const
 {
     return read_ids_d_;
 }
 
 template <typename SketchElementImpl>
-const thrust::device_vector<position_in_read_t>& IndexGPU<SketchElementImpl>::positions_in_reads() const
+const device_buffer<position_in_read_t>& IndexGPU<SketchElementImpl>::positions_in_reads() const
 {
     return positions_in_reads_d_;
 }
 
 template <typename SketchElementImpl>
-const thrust::device_vector<typename SketchElementImpl::DirectionOfRepresentation>& IndexGPU<SketchElementImpl>::directions_of_reads() const
+const device_buffer<typename SketchElementImpl::DirectionOfRepresentation>& IndexGPU<SketchElementImpl>::directions_of_reads() const
 {
     return directions_of_reads_d_;
 }
 
 template <typename SketchElementImpl>
-const thrust::device_vector<representation_t>& IndexGPU<SketchElementImpl>::unique_representations() const
+const device_buffer<representation_t>& IndexGPU<SketchElementImpl>::unique_representations() const
 {
     return unique_representations_d_;
 }
 
 template <typename SketchElementImpl>
-const thrust::device_vector<std::uint32_t>& IndexGPU<SketchElementImpl>::first_occurrence_of_representations() const
+const device_buffer<std::uint32_t>& IndexGPU<SketchElementImpl>::first_occurrence_of_representations() const
 {
     return first_occurrence_of_representations_d_;
 }
@@ -715,8 +725,8 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
 
     // copy the data to member functions (depending on the interface desing these copies might not be needed)
     representations_d_.resize(representations_d.size());
-    if (representations_d_.capacity() > representations_d_.size())
-        representations_d_.shrink_to_fit();
+    //if (representations_d_.capacity() > representations_d_.size())
+    representations_d_.shrink_to_fit();
     thrust::copy(thrust::device,
                  representations_d.data(),
                  representations_d.data() + representations_d.size(),
@@ -724,22 +734,22 @@ void IndexGPU<SketchElementImpl>::generate_index(const io::FastaParser& parser,
     representations_d.free();
 
     read_ids_d_.resize(representations_d_.size());
-    if (read_ids_d_.capacity() > read_ids_d_.size())
-        read_ids_d_.shrink_to_fit();
+    //if (read_ids_d_.capacity() > read_ids_d_.size())
+    read_ids_d_.shrink_to_fit();
     positions_in_reads_d_.resize(representations_d_.size());
-    if (positions_in_reads_d_.capacity() > positions_in_reads_d_.size())
-        positions_in_reads_d_.shrink_to_fit();
+    //if (positions_in_reads_d_.capacity() > positions_in_reads_d_.size())
+    positions_in_reads_d_.shrink_to_fit();
     directions_of_reads_d_.resize(representations_d_.size());
-    if (directions_of_reads_d_.capacity() > directions_of_reads_d_.size())
-        directions_of_reads_d_.shrink_to_fit();
+    //if (directions_of_reads_d_.capacity() > directions_of_reads_d_.size())
+    directions_of_reads_d_.shrink_to_fit();
 
     const std::uint32_t threads = 256;
     const std::uint32_t blocks  = ceiling_divide<int64_t>(representations_d_.size(), threads);
 
     details::index_gpu::copy_rest_to_separate_arrays<<<blocks, threads>>>(rest_d.data(),
-                                                                          read_ids_d_.data().get(),
-                                                                          positions_in_reads_d_.data().get(),
-                                                                          directions_of_reads_d_.data().get(),
+                                                                          read_ids_d_.data(),
+                                                                          positions_in_reads_d_.data(),
+                                                                          directions_of_reads_d_.data(),
                                                                           representations_d_.size());
 
     // now generate the index elements

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -515,12 +515,12 @@ void filter_out_most_common_representations(std::shared_ptr<DeviceAllocator> all
                                                                                          directions_of_representations_after_compression_d.data());
 
     // *** swap vectors with the input arrays ***
-    std::swap(unique_representations_d, unique_representations_after_compression_d);
-    std::swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
-    std::swap(representations_d, representations_after_compression_d);
-    std::swap(read_ids_d, read_ids_after_compression_d);
-    std::swap(positions_in_reads_d, positions_in_reads_after_compression_d);
-    std::swap(directions_of_representations_d, directions_of_representations_after_compression_d);
+    swap(unique_representations_d, unique_representations_after_compression_d);
+    swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
+    swap(representations_d, representations_after_compression_d);
+    swap(read_ids_d, read_ids_after_compression_d);
+    swap(positions_in_reads_d, positions_in_reads_after_compression_d);
+    swap(directions_of_representations_d, directions_of_representations_after_compression_d);
 }
 
 } // namespace index_gpu

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -515,12 +515,12 @@ void filter_out_most_common_representations(std::shared_ptr<DeviceAllocator> all
                                                                                          directions_of_representations_after_compression_d.data());
 
     // *** swap vectors with the input arrays ***
-    claragenomics::swap(unique_representations_d, unique_representations_after_compression_d);
-    claragenomics::swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
-    claragenomics::swap(representations_d, representations_after_compression_d);
-    claragenomics::swap(read_ids_d, read_ids_after_compression_d);
-    claragenomics::swap(positions_in_reads_d, positions_in_reads_after_compression_d);
-    claragenomics::swap(directions_of_representations_d, directions_of_representations_after_compression_d);
+    std::swap(unique_representations_d, unique_representations_after_compression_d);
+    std::swap(first_occurrence_of_representations_d, first_occurrence_of_representations_after_compression_d);
+    std::swap(representations_d, representations_after_compression_d);
+    std::swap(read_ids_d, read_ids_after_compression_d);
+    std::swap(positions_in_reads_d, positions_in_reads_after_compression_d);
+    std::swap(directions_of_representations_d, directions_of_representations_after_compression_d);
 }
 
 } // namespace index_gpu

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -18,7 +18,6 @@
 #include <future>
 #include <thread>
 #include <atomic>
-#include <map>
 
 #include <claragenomics/logging/logging.hpp>
 #include <claragenomics/io/fasta_parser.hpp>
@@ -225,7 +224,11 @@ int main(int argc, char* argv[])
         index_cache[device_id].erase(key);
     };
 
-    std::shared_ptr<claragenomics::deviceAllocator> allocator(new claragenomics::defaultDeviceAllocator());
+#ifdef CGA_ENABLE_ALLOCATOR
+    std::shared_ptr<claragenomics::deviceAllocator> allocator(new claragenomics::cachingDeviceAllocator());
+#else
+    std::shared_ptr<claragenomics::deviceAllocator> allocator(new claragenomics::deviceAllocator());
+#endif
 
     auto compute_overlaps = [&](const query_target_range query_target_range, const int device_id) {
         std::vector<std::shared_ptr<std::future<void>>> print_pafs_futures;

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -107,7 +107,7 @@ int main(int argc, char* argv[])
 
     if (max_cached_memory <= 0)
     {
-        std::cerr << "-m / --max-cached-memory must be non-zero" << std::endl;
+        std::cerr << "-m / --max-cached-memory must be larger than zero" << std::endl;
         exit(1);
     }
 

--- a/cudamapper/src/matcher.cu
+++ b/cudamapper/src/matcher.cu
@@ -16,10 +16,11 @@ namespace claragenomics
 namespace cudamapper
 {
 
-std::unique_ptr<Matcher> Matcher::create_matcher(const Index& query_index,
+std::unique_ptr<Matcher> Matcher::create_matcher(std::shared_ptr<deviceAllocator> allocator,
+						 const Index& query_index,
                                                  const Index& target_index)
 {
-    return std::make_unique<MatcherGPU>(query_index, target_index);
+    return std::make_unique<MatcherGPU>(allocator, query_index, target_index);
 }
 
 } // namespace cudamapper

--- a/cudamapper/src/matcher.cu
+++ b/cudamapper/src/matcher.cu
@@ -16,8 +16,8 @@ namespace claragenomics
 namespace cudamapper
 {
 
-std::unique_ptr<Matcher> Matcher::create_matcher(std::shared_ptr<deviceAllocator> allocator,
-						 const Index& query_index,
+std::unique_ptr<Matcher> Matcher::create_matcher(std::shared_ptr<DeviceAllocator> allocator,
+                                                 const Index& query_index,
                                                  const Index& target_index)
 {
     return std::make_unique<MatcherGPU>(allocator, query_index, target_index);

--- a/cudamapper/src/matcher_gpu.cu
+++ b/cudamapper/src/matcher_gpu.cu
@@ -60,9 +60,10 @@ namespace claragenomics
 namespace cudamapper
 {
 
-MatcherGPU::MatcherGPU(const Index& query_index,
+MatcherGPU::MatcherGPU(std::shared_ptr<deviceAllocator> allocator,
+		       const Index& query_index,
                        const Index& target_index)
-{
+    :anchors_d_(allocator){
     CGA_NVTX_RANGE(profile, "matcherGPU");
     if (query_index.unique_representations().size() == 0 || target_index.unique_representations().size() == 0)
         return;
@@ -78,8 +79,8 @@ MatcherGPU::MatcherGPU(const Index& query_index,
     // The array index of the following data structures will correspond to the array index of the
     // unique representation in the query index.
 
-    device_buffer<std::int64_t> found_target_indices_d(query_index.unique_representations().size());
-    device_buffer<std::int64_t> anchor_starting_indices_d(query_index.unique_representations().size());
+    device_buffer<std::int64_t> found_target_indices_d(query_index.unique_representations().size(), allocator);
+    device_buffer<std::int64_t> anchor_starting_indices_d(query_index.unique_representations().size(), allocator);
 
     // First we search for each unique representation of the query index, the array index
     // of the same representation in the array of unique representations of target index
@@ -90,7 +91,7 @@ MatcherGPU::MatcherGPU(const Index& query_index,
     // and store the resulting starting index in an anchors array if all anchors are stored in a flat array.
     // The last element will be the total number of anchors.
     details::matcher_gpu::compute_anchor_starting_indices(anchor_starting_indices_d, query_index.first_occurrence_of_representations(), found_target_indices_d, target_index.first_occurrence_of_representations());
-
+    
     int64_t n_anchors = 0;
     cudautils::copy(&n_anchors, anchor_starting_indices_d.end() - 1, 1); // D->H transfer
     //const int64_t n_anchors = anchor_starting_indices_d.back(); // D->H transfer
@@ -199,7 +200,6 @@ void generate_anchors(
     assert(found_target_indices_d.size() + 1 == query_starting_index_of_each_representation_d.size());
     assert(query_read_ids.size() == query_positions_in_read.size());
     assert(target_read_ids.size() == target_positions_in_read.size());
-
     const int32_t n_threads = 256;
     const int32_t n_blocks  = ceiling_divide<int64_t>(get_size(anchors), n_threads);
     generate_anchors_kernel<<<n_blocks, n_threads>>>(

--- a/cudamapper/src/matcher_gpu.cu
+++ b/cudamapper/src/matcher_gpu.cu
@@ -60,10 +60,11 @@ namespace claragenomics
 namespace cudamapper
 {
 
-MatcherGPU::MatcherGPU(std::shared_ptr<deviceAllocator> allocator,
-		       const Index& query_index,
+MatcherGPU::MatcherGPU(std::shared_ptr<DeviceAllocator> allocator,
+                       const Index& query_index,
                        const Index& target_index)
-    :anchors_d_(allocator){
+    : anchors_d_(allocator)
+{
     CGA_NVTX_RANGE(profile, "matcherGPU");
     if (query_index.unique_representations().size() == 0 || target_index.unique_representations().size() == 0)
         return;
@@ -91,10 +92,8 @@ MatcherGPU::MatcherGPU(std::shared_ptr<deviceAllocator> allocator,
     // and store the resulting starting index in an anchors array if all anchors are stored in a flat array.
     // The last element will be the total number of anchors.
     details::matcher_gpu::compute_anchor_starting_indices(anchor_starting_indices_d, query_index.first_occurrence_of_representations(), found_target_indices_d, target_index.first_occurrence_of_representations());
-    
-    int64_t n_anchors = 0;
-    cudautils::copy(&n_anchors, anchor_starting_indices_d.end() - 1, 1); // D->H transfer
-    //const int64_t n_anchors = anchor_starting_indices_d.back(); // D->H transfer
+
+    const int64_t n_anchors = cudautils::get_value_from_device(anchor_starting_indices_d.end() - 1); // D->H transfer
 
     anchors_d_.resize(n_anchors);
 

--- a/cudamapper/src/matcher_gpu.cuh
+++ b/cudamapper/src/matcher_gpu.cuh
@@ -24,8 +24,8 @@ namespace cudamapper
 class MatcherGPU : public Matcher
 {
 public:
-    MatcherGPU(std::shared_ptr<deviceAllocator> allocator,
-	       const Index& query_index,
+    MatcherGPU(std::shared_ptr<DeviceAllocator> allocator,
+               const Index& query_index,
                const Index& target_index);
 
     device_buffer<Anchor>& anchors() override;

--- a/cudamapper/src/matcher_gpu.cuh
+++ b/cudamapper/src/matcher_gpu.cuh
@@ -11,7 +11,7 @@
 #pragma once
 
 #include <vector>
-#include <thrust/device_vector.h>
+#include <claragenomics/utils/device_buffer.hpp>
 #include <claragenomics/cudamapper/matcher.hpp>
 #include <claragenomics/cudamapper/types.hpp>
 
@@ -27,10 +27,10 @@ public:
     MatcherGPU(const Index& query_index,
                const Index& target_index);
 
-    thrust::device_vector<Anchor>& anchors() override;
+    device_buffer<Anchor>& anchors() override;
 
 private:
-    thrust::device_vector<Anchor> anchors_d_;
+    device_buffer<Anchor> anchors_d_;
 };
 
 namespace details
@@ -65,9 +65,9 @@ namespace matcher_gpu
 /// \param query_representations_d An array of query representations
 /// \param target_representations_d An sorted array of target representations
 void find_query_target_matches(
-    thrust::device_vector<std::int64_t>& found_target_indices_d,
-    const thrust::device_vector<representation_t>& query_representations_d,
-    const thrust::device_vector<representation_t>& target_representations_d);
+    device_buffer<std::int64_t>& found_target_indices_d,
+    const device_buffer<representation_t>& query_representations_d,
+    const device_buffer<representation_t>& target_representations_d);
 
 /// \brief Computes the starting indices for an array of anchors based on the matches in query and target arrays.
 ///
@@ -102,10 +102,10 @@ void find_query_target_matches(
 /// \param found_target_indices_d
 /// \param target_starting_index_of_each_representation_d
 void compute_anchor_starting_indices(
-    thrust::device_vector<std::int64_t>& anchor_starting_indices_d,
-    const thrust::device_vector<std::uint32_t>& query_starting_index_of_each_representation_d,
-    const thrust::device_vector<std::int64_t>& found_target_indices_d,
-    const thrust::device_vector<std::uint32_t>& target_starting_index_of_each_representation_d);
+    device_buffer<std::int64_t>& anchor_starting_indices_d,
+    const device_buffer<std::uint32_t>& query_starting_index_of_each_representation_d,
+    const device_buffer<std::int64_t>& found_target_indices_d,
+    const device_buffer<std::uint32_t>& target_starting_index_of_each_representation_d);
 
 /// \brief Generates an array of anchors from matches of representations of the query and target index
 ///
@@ -156,15 +156,15 @@ void compute_anchor_starting_indices(
 /// \param target_read_ids the array of read ids of the (read id, position)-pairs in target index
 /// \param target_positions_in_read the array of positions of the (read id, position)-pairs in target index
 void generate_anchors(
-    thrust::device_vector<Anchor>& anchors,
-    const thrust::device_vector<std::int64_t>& anchor_starting_indices_d,
-    const thrust::device_vector<std::uint32_t>& query_starting_index_of_each_representation_d,
-    const thrust::device_vector<std::int64_t>& found_target_indices_d,
-    const thrust::device_vector<std::uint32_t>& target_starting_index_of_each_representation_d,
-    const thrust::device_vector<read_id_t>& query_read_ids,
-    const thrust::device_vector<position_in_read_t>& query_positions_in_read,
-    const thrust::device_vector<read_id_t>& target_read_ids,
-    const thrust::device_vector<position_in_read_t>& target_positions_in_read);
+    device_buffer<Anchor>& anchors,
+    const device_buffer<std::int64_t>& anchor_starting_indices_d,
+    const device_buffer<std::uint32_t>& query_starting_index_of_each_representation_d,
+    const device_buffer<std::int64_t>& found_target_indices_d,
+    const device_buffer<std::uint32_t>& target_starting_index_of_each_representation_d,
+    const device_buffer<read_id_t>& query_read_ids,
+    const device_buffer<position_in_read_t>& query_positions_in_read,
+    const device_buffer<read_id_t>& target_read_ids,
+    const device_buffer<position_in_read_t>& target_positions_in_read);
 
 /// \brief Performs a binary search on target_representations_d for each element of query_representations_d and stores the found index (or -1 iff not found) in found_target_indices.
 ///

--- a/cudamapper/src/matcher_gpu.cuh
+++ b/cudamapper/src/matcher_gpu.cuh
@@ -24,7 +24,8 @@ namespace cudamapper
 class MatcherGPU : public Matcher
 {
 public:
-    MatcherGPU(const Index& query_index,
+    MatcherGPU(std::shared_ptr<deviceAllocator> allocator,
+	       const Index& query_index,
                const Index& target_index);
 
     device_buffer<Anchor>& anchors() override;

--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -857,7 +857,7 @@ __global__ void compress_minimizers(const representation_t* const window_minimiz
     }
 }
 
-Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(const read_id_t number_of_reads_to_add,
+Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(std::shared_ptr<deviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
                                                                        const std::uint64_t minimizer_size,
                                                                        const std::uint64_t window_size,
                                                                        const std::uint64_t read_id_of_first_read,
@@ -880,20 +880,20 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(const rea
     }
 
     CGA_LOG_INFO("Allocating {} bytes for read_id_to_windows_section_d", read_id_to_windows_section_h.size() * sizeof(decltype(read_id_to_windows_section_h)::value_type));
-    device_buffer<decltype(read_id_to_windows_section_h)::value_type> read_id_to_windows_section_d(read_id_to_windows_section_h.size());
+    device_buffer<decltype(read_id_to_windows_section_h)::value_type> read_id_to_windows_section_d(read_id_to_windows_section_h.size(), allocator);
     CGA_CU_CHECK_ERR(cudaMemcpy(read_id_to_windows_section_d.data(),
                                 read_id_to_windows_section_h.data(),
                                 read_id_to_windows_section_h.size() * sizeof(decltype(read_id_to_windows_section_h)::value_type),
                                 cudaMemcpyHostToDevice));
 
     CGA_LOG_INFO("Allocating {} bytes for window_minimizers_representation_d", total_windows * sizeof(representation_t));
-    device_buffer<representation_t> window_minimizers_representation_d(total_windows);
+    device_buffer<representation_t> window_minimizers_representation_d(total_windows, allocator);
     CGA_LOG_INFO("Allocating {} bytes for window_minimizers_direction_d", total_windows * sizeof(char));
-    device_buffer<char> window_minimizers_direction_d(total_windows);
+    device_buffer<char> window_minimizers_direction_d(total_windows, allocator);
     CGA_LOG_INFO("Allocating {} bytes for window_minimizers_position_in_read_d", total_windows * sizeof(position_in_read_t));
-    device_buffer<position_in_read_t> window_minimizers_position_in_read_d(total_windows);
+    device_buffer<position_in_read_t> window_minimizers_position_in_read_d(total_windows, allocator);
     CGA_LOG_INFO("Allocating {} bytes for read_id_to_minimizers_written_d", number_of_reads_to_add * sizeof(std::uint32_t));
-    device_buffer<std::uint32_t> read_id_to_minimizers_written_d(number_of_reads_to_add);
+    device_buffer<std::uint32_t> read_id_to_minimizers_written_d(number_of_reads_to_add, allocator);
     // initially there are no minimizers written to the output arrays
     CGA_CU_CHECK_ERR(cudaMemset(read_id_to_minimizers_written_d.data(), 0, number_of_reads_to_add * sizeof(std::uint32_t)));
 
@@ -1019,17 +1019,17 @@ Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(const rea
     }
 
     CGA_LOG_INFO("Allocating {} bytes for read_id_to_compressed_minimizers_d", read_id_to_compressed_minimizers_h.size() * sizeof(decltype(read_id_to_compressed_minimizers_h)::value_type));
-    device_buffer<decltype(read_id_to_compressed_minimizers_h)::value_type> read_id_to_compressed_minimizers_d(read_id_to_compressed_minimizers_h.size());
+    device_buffer<decltype(read_id_to_compressed_minimizers_h)::value_type> read_id_to_compressed_minimizers_d(read_id_to_compressed_minimizers_h.size(), allocator);
     CGA_CU_CHECK_ERR(cudaMemcpy(read_id_to_compressed_minimizers_d.data(),
                                 read_id_to_compressed_minimizers_h.data(),
                                 read_id_to_compressed_minimizers_h.size() * sizeof(decltype(read_id_to_compressed_minimizers_h)::value_type),
                                 cudaMemcpyHostToDevice));
 
     CGA_LOG_INFO("Allocating {} bytes for representations_compressed_d", total_minimizers * sizeof(representation_t));
-    device_buffer<representation_t> representations_compressed_d(total_minimizers);
+    device_buffer<representation_t> representations_compressed_d(total_minimizers, allocator);
     // rest = position_in_read, direction and read_id
     CGA_LOG_INFO("Allocating {} bytes for rest_compressed_d", total_minimizers * sizeof(ReadidPositionDirection));
-    device_buffer<ReadidPositionDirection> rest_compressed_d(total_minimizers);
+    device_buffer<ReadidPositionDirection> rest_compressed_d(total_minimizers, allocator);
 
     CGA_LOG_INFO("Launching compress_minimizers with {} bytes of shared memory", 0);
     compress_minimizers<<<number_of_reads_to_add, 128>>>(window_minimizers_representation_d.data(),

--- a/cudamapper/src/minimizer.cu
+++ b/cudamapper/src/minimizer.cu
@@ -857,7 +857,7 @@ __global__ void compress_minimizers(const representation_t* const window_minimiz
     }
 }
 
-Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(std::shared_ptr<deviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
+Minimizer::GeneratedSketchElements Minimizer::generate_sketch_elements(std::shared_ptr<DeviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
                                                                        const std::uint64_t minimizer_size,
                                                                        const std::uint64_t window_size,
                                                                        const std::uint64_t read_id_of_first_read,

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -14,7 +14,6 @@
 #include <vector>
 #include <claragenomics/cudamapper/sketch_element.hpp>
 #include <claragenomics/cudamapper/types.hpp>
-
 #include <claragenomics/utils/device_buffer.hpp>
 
 namespace claragenomics
@@ -81,7 +80,7 @@ public:
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (host memory)
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (device memory)
     /// \param hash_minimizers if true, apply a hash function to the representations
-    static GeneratedSketchElements generate_sketch_elements(const read_id_t number_of_reads_to_add,
+    static GeneratedSketchElements generate_sketch_elements(std::shared_ptr<deviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
                                                             const std::uint64_t minimizer_size,
                                                             const std::uint64_t window_size,
                                                             const std::uint64_t read_id_of_first_read,

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -15,7 +15,7 @@
 #include <claragenomics/cudamapper/sketch_element.hpp>
 #include <claragenomics/cudamapper/types.hpp>
 
-#include <claragenomics/utils/device_buffer.cuh>
+#include <claragenomics/utils/device_buffer.hpp>
 
 namespace claragenomics
 {

--- a/cudamapper/src/minimizer.hpp
+++ b/cudamapper/src/minimizer.hpp
@@ -80,7 +80,7 @@ public:
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (host memory)
     /// \param read_id_to_basepairs_section_h for each read_id points to the section of merged_basepairs_d that belong to that read_id (device memory)
     /// \param hash_minimizers if true, apply a hash function to the representations
-    static GeneratedSketchElements generate_sketch_elements(std::shared_ptr<deviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
+    static GeneratedSketchElements generate_sketch_elements(std::shared_ptr<DeviceAllocator> allocator, const std::uint64_t number_of_reads_to_add,
                                                             const std::uint64_t minimizer_size,
                                                             const std::uint64_t window_size,
                                                             const std::uint64_t read_id_of_first_read,

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -150,6 +150,7 @@ struct CreateOverlap
         new_overlap.query_start_position_in_read_ =
             overlap_start_anchor.query_position_in_read_;
         new_overlap.overlap_complete = true;
+        new_overlap.cigar_           = 0;
 
         // If the target start position is greater than the target end position
         // We can safely assume that the query and target are template and

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -248,7 +248,6 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
 
     // memcpy D2H
     auto n_chains = cudautils::get_value_from_device(d_nchains.data(), stream);
-    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
     // use prefix sum to calculate the starting index position of all the chains
     // >>>>>>>>>>>>
@@ -333,7 +332,6 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
 
     // memcpyD2H
     auto n_fused_overlap = cudautils::get_value_from_device(d_nfused_overlaps.data(), stream);
-    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
     // construct overlap from the overlap args
     CreateOverlap fuse_op(d_anchors.data());

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -172,8 +172,19 @@ struct CreateOverlap
     };
 };
 
+OverlapperTriggered::OverlapperTriggered(std::shared_ptr<deviceAllocator> allocator)
+    : _allocator(allocator)
+{
+    CGA_CU_CHECK_ERR(cudaStreamCreate(&stream));
+}
+OverlapperTriggered::~OverlapperTriggered()
+{
+    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
+    CGA_CU_CHECK_ERR(cudaStreamDestroy(stream));
+}
+
 void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
-                                       thrust::device_vector<Anchor>& d_anchors,
+                                       device_buffer<Anchor>& d_anchors,
                                        const Index& index_query,
                                        const Index& index_target)
 {
@@ -195,66 +206,70 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
                 (i.target_position_in_read_ < j.target_position_in_read_));
     };
 
+    auto thrust_exec_policy = thrust::cuda::par.on(stream);
+
     // sort on device
     // TODO : currently thrust::sort requires O(2N) auxiliary storage, implement the same functionality using O(N) auxiliary storage
-    thrust::sort(thrust::device, d_anchors.begin(), d_anchors.end(), comp);
+    thrust::sort(thrust_exec_policy, d_anchors.begin(), d_anchors.end(), comp);
 
     // temporary workspace buffer on device
-    thrust::device_vector<char> d_temp_buf;
+    device_buffer<char> d_temp_buf(_allocator, stream);
 
     // Do run length encode to compute the chains
     // note - identifies the start and end anchor of the chain without moving the anchors
     // >>>>>>>>>
 
     // d_start_anchor[i] contains the starting anchor of chain i
-    thrust::device_vector<Anchor> d_start_anchor(n_anchors);
+    device_buffer<Anchor> d_start_anchor(n_anchors, _allocator, stream);
 
     // d_chain_length[i] contains the length of chain i
-    thrust::device_vector<int32_t> d_chain_length(n_anchors);
+    device_buffer<int32_t> d_chain_length(n_anchors, _allocator, stream);
 
     // total number of chains found
-    thrust::device_vector<int32_t> d_nchains(1);
+    device_buffer<int32_t> d_nchains(1, _allocator, stream);
 
     void* d_temp_storage      = nullptr;
     size_t temp_storage_bytes = 0;
     // calculate storage requirement for run length encoding
     cub::DeviceRunLengthEncode::Encode(
         d_temp_storage, temp_storage_bytes, d_anchors.data(), d_start_anchor.data(),
-        d_chain_length.data(), d_nchains.data(), n_anchors);
+        d_chain_length.data(), d_nchains.data(), n_anchors, stream);
 
     // allocate temporary storage
-    d_temp_buf.resize(temp_storage_bytes);
-    d_temp_storage = d_temp_buf.data().get();
+    d_temp_buf.resize(temp_storage_bytes, stream);
+    d_temp_storage = d_temp_buf.data();
 
     // run encoding
     cub::DeviceRunLengthEncode::Encode(
         d_temp_storage, temp_storage_bytes, d_anchors.data(), d_start_anchor.data(),
-        d_chain_length.data(), d_nchains.data(), n_anchors);
+        d_chain_length.data(), d_nchains.data(), n_anchors, stream);
 
     // <<<<<<<<<<
 
     // memcpy D2H
-    auto n_chains = d_nchains[0];
+    auto n_chains = 0;
+    cudautils::copy(&n_chains, d_nchains.data(), 1, stream);
+    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
     // use prefix sum to calculate the starting index position of all the chains
     // >>>>>>>>>>>>
 
     // for a chain i, d_chain_start[i] contains the index of starting anchor from d_anchors array
-    thrust::device_vector<int32_t> d_chain_start(n_chains);
+    device_buffer<int32_t> d_chain_start(n_chains, _allocator, stream);
 
     d_temp_storage     = nullptr;
     temp_storage_bytes = 0;
     cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes,
                                   d_chain_length.data(), d_chain_start.data(),
-                                  n_chains);
+                                  n_chains, stream);
 
     // allocate temporary storage
-    d_temp_buf.resize(temp_storage_bytes);
-    d_temp_storage = d_temp_buf.data().get();
+    d_temp_buf.resize(temp_storage_bytes, stream);
+    d_temp_storage = d_temp_buf.data();
 
     cub::DeviceScan::ExclusiveSum(d_temp_storage, temp_storage_bytes,
                                   d_chain_length.data(), d_chain_start.data(),
-                                  n_chains);
+                                  n_chains, stream);
 
     // <<<<<<<<<<<<
 
@@ -264,9 +279,9 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
     // d_overlaps[j] contains index to d_chain_length/d_chain_start where
     // d_chain_length[d_overlaps[j]] and d_chain_start[d_overlaps[j]] corresponds
     // to length and index to starting anchor of the chain-d_overlaps[j] (also referred as overlap j)
-    thrust::device_vector<int32_t> d_overlaps(n_chains);
+    device_buffer<int32_t> d_overlaps(n_chains, _allocator, stream);
     auto indices_end =
-        thrust::copy_if(thrust::make_counting_iterator<int32_t>(0),
+        thrust::copy_if(thrust_exec_policy, thrust::make_counting_iterator<int32_t>(0),
                         thrust::make_counting_iterator<int32_t>(n_chains),
                         d_chain_length.data(), d_overlaps.data(),
                         [=] __host__ __device__(const int32_t& len) -> bool {
@@ -274,29 +289,30 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
                         });
 
     auto n_overlaps = indices_end - d_overlaps.data();
+
     // <<<<<<<<<<<<<
 
     // >>>>>>>>>>>>
     // fuse overlaps using reduce by key operations
 
     // key is a minimal data structure that is required to compare the overlaps
-    cuOverlapKey_transform key_op(d_anchors.data().get(),
-                                  d_chain_start.data().get());
+    cuOverlapKey_transform key_op(d_anchors.data(),
+                                  d_chain_start.data());
     cub::TransformInputIterator<cuOverlapKey, cuOverlapKey_transform, int32_t*>
-        d_keys_in(d_overlaps.data().get(),
+        d_keys_in(d_overlaps.data(),
                   key_op);
 
     // value is a minimal data structure that represents a overlap
-    cuOverlapArgs_transform value_op(d_chain_start.data().get(),
-                                     d_chain_length.data().get());
+    cuOverlapArgs_transform value_op(d_chain_start.data(),
+                                     d_chain_length.data());
 
     cub::TransformInputIterator<cuOverlapArgs, cuOverlapArgs_transform, int32_t*>
-        d_values_in(d_overlaps.data().get(),
+        d_values_in(d_overlaps.data(),
                     value_op);
 
-    thrust::device_vector<cuOverlapKey> d_fusedoverlap_keys(n_overlaps);
-    thrust::device_vector<cuOverlapArgs> d_fusedoverlaps_args(n_overlaps);
-    thrust::device_vector<int32_t> d_nfused_overlaps(1);
+    device_buffer<cuOverlapKey> d_fusedoverlap_keys(n_overlaps, _allocator, stream);
+    device_buffer<cuOverlapArgs> d_fusedoverlaps_args(n_overlaps, _allocator, stream);
+    device_buffer<int32_t> d_nfused_overlaps(1, _allocator, stream);
 
     FuseOverlapOp reduction_op;
 
@@ -305,33 +321,35 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
     cub::DeviceReduce::ReduceByKey(d_temp_storage, temp_storage_bytes, d_keys_in,
                                    d_fusedoverlap_keys.data(), d_values_in,
                                    d_fusedoverlaps_args.data(), d_nfused_overlaps.data(),
-                                   reduction_op, n_overlaps);
+                                   reduction_op, n_overlaps, stream);
 
     // allocate temporary storage
-    d_temp_buf.resize(temp_storage_bytes);
-    d_temp_storage = d_temp_buf.data().get();
+    d_temp_buf.resize(temp_storage_bytes, stream);
+    d_temp_storage = d_temp_buf.data();
 
     cub::DeviceReduce::ReduceByKey(d_temp_storage, temp_storage_bytes, d_keys_in,
                                    d_fusedoverlap_keys.data(), d_values_in,
                                    d_fusedoverlaps_args.data(), d_nfused_overlaps.data(),
-                                   reduction_op, n_overlaps);
+                                   reduction_op, n_overlaps, stream);
 
     // memcpyD2H
-    auto n_fused_overlap = d_nfused_overlaps[0];
+    auto n_fused_overlap = 0;
+    cudautils::copy(&n_fused_overlap, d_nfused_overlaps.data(), 1, stream);
+    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
     // construct overlap from the overlap args
-    CreateOverlap fuse_op(d_anchors.data().get());
-    thrust::device_vector<Overlap> d_fused_overlaps(n_fused_overlap);
-    thrust::transform(d_fusedoverlaps_args.data(),
+    CreateOverlap fuse_op(d_anchors.data());
+    device_buffer<Overlap> d_fused_overlaps(n_fused_overlap, _allocator, stream);
+    thrust::transform(thrust_exec_policy, d_fusedoverlaps_args.data(),
                       d_fusedoverlaps_args.data() + n_fused_overlap,
                       d_fused_overlaps.data(), fuse_op);
 
     // memcpyD2H - move fused overlaps to host
     fused_overlaps.resize(n_fused_overlap);
-    thrust::copy(d_fused_overlaps.begin(), d_fused_overlaps.end(),
-                 fused_overlaps.begin());
-    // <<<<<<<<<<<<
+    cudautils::copy(fused_overlaps.data(), d_fused_overlaps.data(), n_fused_overlap, stream);
+    CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
+    // <<<<<<<<<<<<
     // parallel update the overlaps to include the corresponding read names [parallel on host]
     thrust::transform(thrust::host,
                       fused_overlaps.data(),

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -14,6 +14,7 @@
 
 #include <claragenomics/cudamapper/types.hpp>
 #include <claragenomics/cudamapper/overlapper.hpp>
+#include <claragenomics/utils/device_buffer.hpp>
 
 namespace claragenomics
 {
@@ -37,7 +38,14 @@ public:
     /// \param index_query Index
     /// \param index_target
     /// \return vector of Overlap objects
-    void get_overlaps(std::vector<Overlap>& overlaps, thrust::device_vector<Anchor>& anchors, const Index& index_query, const Index& index_target) override;
+    void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors, const Index& index_query, const Index& index_target) override;
+
+    OverlapperTriggered(std::shared_ptr<deviceAllocator>);
+    ~OverlapperTriggered();
+
+private:
+    std::shared_ptr<deviceAllocator> _allocator;
+    cudaStream_t stream;
 };
 } // namespace cudamapper
 } // namespace claragenomics

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -40,11 +40,11 @@ public:
     /// \return vector of Overlap objects
     void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors, const Index& index_query, const Index& index_target) override;
 
-    OverlapperTriggered(std::shared_ptr<deviceAllocator>);
+    OverlapperTriggered(std::shared_ptr<DeviceAllocator>);
     ~OverlapperTriggered();
 
 private:
-    std::shared_ptr<deviceAllocator> _allocator;
+    std::shared_ptr<DeviceAllocator> _allocator;
     cudaStream_t stream;
 };
 } // namespace cudamapper

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -40,7 +40,7 @@ public:
     /// \return vector of Overlap objects
     void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors, const Index& index_query, const Index& index_target) override;
 
-    OverlapperTriggered(std::shared_ptr<DeviceAllocator>);
+    explicit OverlapperTriggered(std::shared_ptr<DeviceAllocator>);
     ~OverlapperTriggered();
 
 private:

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -165,7 +165,7 @@ void test_find_first_occurrences_of_representations(const thrust::host_vector<re
                                                     const thrust::host_vector<std::uint32_t>& expected_starting_index_of_each_representation_h,
                                                     const thrust::host_vector<representation_t>& expected_unique_representations_h)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     device_buffer<representation_t> representations_d(representations_h.size(), allocator);
     cudautils::device_copy_n(representations_h.data(), representations_h.size(), representations_d.data()); // H2D
 
@@ -954,7 +954,7 @@ void test_filter_out_most_common_representations(const double filtering_paramete
     ASSERT_EQ(expected_output_unique_representations_h.size(), expected_output_first_occurrence_of_representations_h.size() - 1);
     ASSERT_EQ(expected_output_representations_h.size(), expected_output_first_occurrence_of_representations_h.back());
 
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
 
     device_buffer<representation_t> representations_d(input_representations_h.size(), allocator);
     cudautils::device_copy_n(input_representations_h.data(), input_representations_h.size(), representations_d.data()); // H2D
@@ -1286,8 +1286,8 @@ void test_function(const std::string& filename,
                    const position_in_read_t expected_number_of_basepairs_in_longest_read,
                    const double filtering_parameter = 1.0)
 {
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename);
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::unique_ptr<io::FastaParser> parser    = io::create_fasta_parser(filename);
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     IndexGPU<Minimizer> index(allocator,
                               *parser,
                               first_read_id,

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -165,16 +165,22 @@ void test_find_first_occurrences_of_representations(const thrust::host_vector<re
                                                     const thrust::host_vector<std::uint32_t>& expected_starting_index_of_each_representation_h,
                                                     const thrust::host_vector<representation_t>& expected_unique_representations_h)
 {
-    const thrust::device_vector<representation_t> representations_d(representations_h);
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    device_buffer<representation_t> representations_d(representations_h.size(), allocator);
+    cudautils::device_copy_n(representations_h.data(), representations_h.size(), representations_d.data()); // H2D
 
-    thrust::device_vector<std::uint32_t> starting_index_of_each_representation_d;
-    thrust::device_vector<representation_t> unique_representations_d;
-    find_first_occurrences_of_representations(unique_representations_d,
+    device_buffer<std::uint32_t> starting_index_of_each_representation_d(allocator);
+    device_buffer<representation_t> unique_representations_d(allocator);
+
+    find_first_occurrences_of_representations(allocator,
+                                              unique_representations_d,
                                               starting_index_of_each_representation_d,
                                               representations_d);
 
-    const thrust::host_vector<std::uint32_t> starting_index_of_each_representation_h(starting_index_of_each_representation_d);
-    const thrust::host_vector<representation_t> unique_representations_h(unique_representations_d);
+    thrust::host_vector<std::uint32_t> starting_index_of_each_representation_h(starting_index_of_each_representation_d.size());
+    cudautils::device_copy_n(starting_index_of_each_representation_d.data(), starting_index_of_each_representation_d.size(), starting_index_of_each_representation_h.data()); // D2H
+    thrust::host_vector<representation_t> unique_representations_h(unique_representations_d.size());
+    cudautils::device_copy_n(unique_representations_d.data(), unique_representations_d.size(), unique_representations_h.data()); //D2H
 
     ASSERT_EQ(starting_index_of_each_representation_h.size(), expected_starting_index_of_each_representation_h.size());
     ASSERT_EQ(unique_representations_h.size(), expected_unique_representations_h.size());
@@ -948,14 +954,23 @@ void test_filter_out_most_common_representations(const double filtering_paramete
     ASSERT_EQ(expected_output_unique_representations_h.size(), expected_output_first_occurrence_of_representations_h.size() - 1);
     ASSERT_EQ(expected_output_representations_h.size(), expected_output_first_occurrence_of_representations_h.back());
 
-    thrust::device_vector<representation_t> representations_d(input_representations_h);
-    thrust::device_vector<read_id_t> read_ids_d(input_read_ids_h);
-    thrust::device_vector<position_in_read_t> positions_in_reads_d(input_positions_in_reads_h);
-    thrust::device_vector<DirectionOfRepresentation> directions_of_representations_d(input_directions_of_representations_h);
-    thrust::device_vector<representation_t> unique_representations_d(input_unique_representations_h);
-    thrust::device_vector<std::uint32_t> first_occurrence_of_representations_d(input_first_occurrence_of_representations_h);
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
 
-    filter_out_most_common_representations(filtering_parameter,
+    device_buffer<representation_t> representations_d(input_representations_h.size(), allocator);
+    cudautils::device_copy_n(input_representations_h.data(), input_representations_h.size(), representations_d.data()); // H2D
+    device_buffer<read_id_t> read_ids_d(input_read_ids_h.size(), allocator);
+    cudautils::device_copy_n(input_read_ids_h.data(), input_read_ids_h.size(), read_ids_d.data()); // H2D
+    device_buffer<position_in_read_t> positions_in_reads_d(input_positions_in_reads_h.size(), allocator);
+    cudautils::device_copy_n(input_positions_in_reads_h.data(), input_positions_in_reads_h.size(), positions_in_reads_d.data()); // H2D
+    device_buffer<DirectionOfRepresentation> directions_of_representations_d(input_directions_of_representations_h.size(), allocator);
+    cudautils::device_copy_n(input_directions_of_representations_h.data(), input_directions_of_representations_h.size(), directions_of_representations_d.data()); // H2D
+    device_buffer<representation_t> unique_representations_d(input_unique_representations_h.size(), allocator);
+    cudautils::device_copy_n(input_unique_representations_h.data(), input_unique_representations_h.size(), unique_representations_d.data()); // H2D
+    device_buffer<std::uint32_t> first_occurrence_of_representations_d(input_first_occurrence_of_representations_h.size(), allocator);
+    cudautils::device_copy_n(input_first_occurrence_of_representations_h.data(), input_first_occurrence_of_representations_h.size(), first_occurrence_of_representations_d.data()); // H2D
+
+    filter_out_most_common_representations(allocator,
+                                           filtering_parameter,
                                            representations_d,
                                            read_ids_d,
                                            positions_in_reads_d,
@@ -963,12 +978,18 @@ void test_filter_out_most_common_representations(const double filtering_paramete
                                            unique_representations_d,
                                            first_occurrence_of_representations_d);
 
-    thrust::host_vector<representation_t> output_representations_h(representations_d);
-    thrust::host_vector<read_id_t> output_read_ids_h(read_ids_d);
-    thrust::host_vector<position_in_read_t> output_positions_in_reads_h(positions_in_reads_d);
-    thrust::host_vector<DirectionOfRepresentation> output_directions_of_representations_h(directions_of_representations_d);
-    thrust::host_vector<representation_t> output_unique_representations_h(unique_representations_d);
-    thrust::host_vector<std::uint32_t> output_first_occurrence_of_representations_h(first_occurrence_of_representations_d);
+    thrust::host_vector<representation_t> output_representations_h(representations_d.size());
+    cudautils::device_copy_n(representations_d.data(), representations_d.size(), output_representations_h.data()); //D2H
+    thrust::host_vector<read_id_t> output_read_ids_h(read_ids_d.size());
+    cudautils::device_copy_n(read_ids_d.data(), read_ids_d.size(), output_read_ids_h.data()); //D2H
+    thrust::host_vector<position_in_read_t> output_positions_in_reads_h(positions_in_reads_d.size());
+    cudautils::device_copy_n(positions_in_reads_d.data(), positions_in_reads_d.size(), output_positions_in_reads_h.data()); //D2H
+    thrust::host_vector<DirectionOfRepresentation> output_directions_of_representations_h(directions_of_representations_d.size());
+    cudautils::device_copy_n(directions_of_representations_d.data(), directions_of_representations_d.size(), output_directions_of_representations_h.data()); // D2H
+    thrust::host_vector<representation_t> output_unique_representations_h(unique_representations_d.size());
+    cudautils::device_copy_n(unique_representations_d.data(), unique_representations_d.size(), output_unique_representations_h.data()); // D2H
+    thrust::host_vector<std::uint32_t> output_first_occurrence_of_representations_h(first_occurrence_of_representations_d.size());
+    cudautils::device_copy_n(first_occurrence_of_representations_d.data(), first_occurrence_of_representations_d.size(), output_first_occurrence_of_representations_h.data()); // D2H
 
     ASSERT_EQ(expected_output_representations_h.size(), output_representations_h.size());
     ASSERT_EQ(expected_output_representations_h.size(), output_read_ids_h.size());
@@ -1266,7 +1287,9 @@ void test_function(const std::string& filename,
                    const double filtering_parameter = 1.0)
 {
     std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(filename);
-    IndexGPU<Minimizer> index(*parser,
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    IndexGPU<Minimizer> index(allocator,
+                              *parser,
                               first_read_id,
                               past_the_last_read_id,
                               kmer_size,
@@ -1291,14 +1314,18 @@ void test_function(const std::string& filename,
     }
 
     // check arrays
-    const thrust::device_vector<representation_t>& representations_d                             = index.representations();
-    const thrust::device_vector<position_in_read_t>& positions_in_reads_d                        = index.positions_in_reads();
-    const thrust::device_vector<read_id_t>& read_ids_d                                           = index.read_ids();
-    const thrust::device_vector<SketchElement::DirectionOfRepresentation>& directions_of_reads_d = index.directions_of_reads();
-    const thrust::host_vector<representation_t>& representations_h(representations_d);
-    const thrust::host_vector<position_in_read_t>& positions_in_reads_h(positions_in_reads_d);
-    const thrust::host_vector<read_id_t>& read_ids_h(read_ids_d);
-    const thrust::host_vector<SketchElement::DirectionOfRepresentation>& directions_of_reads_h(directions_of_reads_d);
+    const device_buffer<representation_t>& representations_d                             = index.representations();
+    const device_buffer<position_in_read_t>& positions_in_reads_d                        = index.positions_in_reads();
+    const device_buffer<read_id_t>& read_ids_d                                           = index.read_ids();
+    const device_buffer<SketchElement::DirectionOfRepresentation>& directions_of_reads_d = index.directions_of_reads();
+    thrust::host_vector<representation_t> representations_h(representations_d.size());
+    cudautils::device_copy_n(representations_d.data(), representations_d.size(), representations_h.data()); // D2H
+    thrust::host_vector<position_in_read_t> positions_in_reads_h(positions_in_reads_d.size());
+    cudautils::device_copy_n(positions_in_reads_d.data(), positions_in_reads_d.size(), positions_in_reads_h.data()); // D2H
+    thrust::host_vector<read_id_t> read_ids_h(read_ids_d.size());
+    cudautils::device_copy_n(read_ids_d.data(), read_ids_d.size(), read_ids_h.data()); // D2H
+    thrust::host_vector<SketchElement::DirectionOfRepresentation> directions_of_reads_h(directions_of_reads_d.size());
+    cudautils::device_copy_n(directions_of_reads_d.data(), directions_of_reads_d.size(), directions_of_reads_h.data()); // D2H
     ASSERT_EQ(representations_h.size(), expected_representations.size());
     ASSERT_EQ(positions_in_reads_h.size(), expected_positions_in_reads.size());
     ASSERT_EQ(read_ids_h.size(), expected_read_ids.size());
@@ -1314,10 +1341,12 @@ void test_function(const std::string& filename,
         EXPECT_EQ(directions_of_reads_h[i], expected_directions_of_reads[i]) << "i: " << i;
     }
 
-    const thrust::device_vector<representation_t> unique_representations_d           = index.unique_representations();
-    const thrust::device_vector<std::uint32_t> first_occurrence_of_representations_d = index.first_occurrence_of_representations();
-    const thrust::host_vector<representation_t> unique_representations_h(unique_representations_d);
-    const thrust::host_vector<representation_t> first_occurrence_of_representations_h(first_occurrence_of_representations_d);
+    const device_buffer<representation_t>& unique_representations_d           = index.unique_representations();
+    const device_buffer<std::uint32_t>& first_occurrence_of_representations_d = index.first_occurrence_of_representations();
+    thrust::host_vector<representation_t> unique_representations_h(unique_representations_d.size());
+    cudautils::device_copy_n(unique_representations_d.data(), unique_representations_d.size(), unique_representations_h.data()); // D2H
+    thrust::host_vector<std::uint32_t> first_occurrence_of_representations_h(first_occurrence_of_representations_d.size());
+    cudautils::device_copy_n(first_occurrence_of_representations_d.data(), first_occurrence_of_representations_d.size(), first_occurrence_of_representations_h.data()); // D2H
     ASSERT_EQ(expected_unique_representations.size() + 1, expected_first_occurrence_of_representations.size());
     ASSERT_EQ(unique_representations_h.size(), expected_unique_representations.size());
     ASSERT_EQ(first_occurrence_of_representations_h.size(), expected_first_occurrence_of_representations.size());

--- a/cudamapper/tests/Test_CudamapperMatcherGPU.cu
+++ b/cudamapper/tests/Test_CudamapperMatcherGPU.cu
@@ -29,14 +29,17 @@ void test_find_query_target_matches(const thrust::host_vector<representation_t>&
                                     const thrust::host_vector<representation_t>& target_representations_h,
                                     const thrust::host_vector<std::int64_t>& expected_found_target_indices_h)
 {
-    const thrust::device_vector<representation_t> query_representations_d(query_representations_h);
-    const thrust::device_vector<representation_t> target_representations_d(target_representations_h);
-    thrust::device_vector<int64_t> found_target_indices_d(query_representations_d.size());
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    device_buffer<representation_t> query_representations_d(query_representations_h.size(), allocator);
+    cudautils::device_copy_n(query_representations_h.data(), query_representations_h.size(), query_representations_d.data()); // H2D
+    device_buffer<representation_t> target_representations_d(target_representations_h.size(), allocator);
+    cudautils::device_copy_n(target_representations_h.data(), target_representations_h.size(), target_representations_d.data()); // H2D
+    device_buffer<int64_t> found_target_indices_d(query_representations_d.size(), allocator);
 
     details::matcher_gpu::find_query_target_matches(found_target_indices_d, query_representations_d, target_representations_d);
 
-    thrust::device_vector<int64_t> found_target_indices_h(found_target_indices_d);
-
+    thrust::host_vector<int64_t> found_target_indices_h(found_target_indices_d.size());
+    cudautils::device_copy_n(found_target_indices_d.data(), found_target_indices_d.size(), found_target_indices_h.data()); // D2H
     ASSERT_EQ(found_target_indices_h.size(), expected_found_target_indices_h.size());
 
     for (int32_t i = 0; i < get_size(found_target_indices_h); ++i)
@@ -107,15 +110,20 @@ void test_compute_number_of_anchors(const thrust::host_vector<std::uint32_t>& qu
                                     const thrust::host_vector<std::uint32_t>& target_starting_index_of_each_representation_h,
                                     const thrust::host_vector<std::int64_t>& expected_anchor_starting_indices_h)
 {
-    const thrust::device_vector<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h);
-    const thrust::device_vector<std::uint32_t> target_starting_index_of_each_representation_d(target_starting_index_of_each_representation_h);
-    const thrust::device_vector<std::int64_t> found_target_indices_d(found_target_indices_h);
-    thrust::device_vector<std::int64_t> anchor_starting_indices_d(found_target_indices_h.size());
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    device_buffer<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h.size(), allocator);
+    cudautils::device_copy_n(query_starting_index_of_each_representation_h.data(), query_starting_index_of_each_representation_h.size(), query_starting_index_of_each_representation_d.data()); //H2D
+    device_buffer<std::uint32_t> target_starting_index_of_each_representation_d(target_starting_index_of_each_representation_h.size(), allocator);
+    cudautils::device_copy_n(target_starting_index_of_each_representation_h.data(), target_starting_index_of_each_representation_h.size(), target_starting_index_of_each_representation_d.data()); //H2D
+    device_buffer<std::int64_t> found_target_indices_d(found_target_indices_h.size(), allocator);
+    cudautils::device_copy_n(found_target_indices_h.data(), found_target_indices_h.size(), found_target_indices_d.data()); // H2D
+    device_buffer<std::int64_t> anchor_starting_indices_d(found_target_indices_h.size(), allocator);
+    cudautils::device_copy_n(found_target_indices_h.data(), found_target_indices_h.size(), found_target_indices_d.data()); // H2D
 
     details::matcher_gpu::compute_anchor_starting_indices(anchor_starting_indices_d, query_starting_index_of_each_representation_d, found_target_indices_d, target_starting_index_of_each_representation_d);
 
-    thrust::host_vector<std::int64_t> anchor_starting_indices_h(anchor_starting_indices_d);
-
+    thrust::host_vector<std::int64_t> anchor_starting_indices_h(anchor_starting_indices_d.size());
+    cudautils::device_copy_n(anchor_starting_indices_d.data(), anchor_starting_indices_d.size(), anchor_starting_indices_h.data()); // D2H
     for (int32_t i = 0; i < get_size(found_target_indices_h); ++i)
     {
         EXPECT_EQ(anchor_starting_indices_h[i], expected_anchor_starting_indices_h[i]);
@@ -201,16 +209,25 @@ void test_generate_anchors(
     const thrust::host_vector<read_id_t>& target_read_ids_h,
     const thrust::host_vector<position_in_read_t>& target_positions_in_read_h)
 {
-    const thrust::device_vector<std::int64_t> anchor_starting_indices_d(anchor_starting_indices_h);
-    const thrust::device_vector<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h);
-    const thrust::device_vector<std::int64_t> found_target_indices_d(found_target_indices_h);
-    const thrust::device_vector<std::uint32_t> target_starting_index_of_each_representation_d(target_starting_index_of_each_representation_h);
-    const thrust::device_vector<read_id_t> query_read_ids_d(query_read_ids_h);
-    const thrust::device_vector<position_in_read_t> query_positions_in_read_d(query_positions_in_read_h);
-    const thrust::device_vector<read_id_t> target_read_ids_d(target_read_ids_h);
-    const thrust::device_vector<position_in_read_t> target_positions_in_read_d(target_positions_in_read_h);
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    device_buffer<std::int64_t> anchor_starting_indices_d(anchor_starting_indices_h.size(), allocator);
+    cudautils::device_copy_n(anchor_starting_indices_h.data(), anchor_starting_indices_h.size(), anchor_starting_indices_d.data()); // H2D
+    device_buffer<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h.size(), allocator);
+    cudautils::device_copy_n(query_starting_index_of_each_representation_h.data(), query_starting_index_of_each_representation_h.size(), query_starting_index_of_each_representation_d.data()); // H2D
+    device_buffer<std::int64_t> found_target_indices_d(found_target_indices_h.size(), allocator);
+    cudautils::device_copy_n(found_target_indices_h.data(), found_target_indices_h.size(), found_target_indices_d.data()); //H2D
+    device_buffer<std::uint32_t> target_starting_index_of_each_representation_d(target_starting_index_of_each_representation_h.size(), allocator);
+    cudautils::device_copy_n(target_starting_index_of_each_representation_h.data(), target_starting_index_of_each_representation_h.size(), target_starting_index_of_each_representation_d.data()); // H2D
+    device_buffer<read_id_t> query_read_ids_d(query_read_ids_h.size(), allocator);
+    cudautils::device_copy_n(query_read_ids_h.data(), query_read_ids_h.size(), query_read_ids_d.data()); // H2D
+    device_buffer<position_in_read_t> query_positions_in_read_d(query_positions_in_read_h.size(), allocator);
+    cudautils::device_copy_n(query_positions_in_read_h.data(), query_positions_in_read_h.size(), query_positions_in_read_d.data()); // H2D
+    device_buffer<read_id_t> target_read_ids_d(target_read_ids_h.size(), allocator);
+    cudautils::device_copy_n(target_read_ids_h.data(), target_read_ids_h.size(), target_read_ids_d.data()); //H2D
+    device_buffer<position_in_read_t> target_positions_in_read_d(target_positions_in_read_h.size(), allocator);
+    cudautils::device_copy_n(target_positions_in_read_h.data(), target_positions_in_read_h.size(), target_positions_in_read_d.data()); //H2D
 
-    thrust::device_vector<Anchor> anchors_d(anchor_starting_indices_h.back());
+    device_buffer<Anchor> anchors_d(anchor_starting_indices_h.back(), allocator);
 
     details::matcher_gpu::generate_anchors(anchors_d,
                                            anchor_starting_indices_d,
@@ -222,7 +239,8 @@ void test_generate_anchors(
                                            target_read_ids_d,
                                            target_positions_in_read_d);
 
-    thrust::host_vector<Anchor> anchors_h(anchors_d);
+    thrust::host_vector<Anchor> anchors_h(anchors_d.size());
+    cudautils::device_copy_n(anchors_d.data(), anchors_d.size(), anchors_h.data()); // D2H
     ASSERT_EQ(anchors_h.size(), expected_anchors_h.size());
 
     for (int64_t i = 0; i < get_size(anchors_h); ++i)
@@ -329,39 +347,46 @@ TEST(TestCudamapperMatcherGPU, test_generate_anchors_small_example)
 
 TEST(TestCudamapperMatcherGPU, OneReadOneMinimizer)
 {
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
     std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> query_index      = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> target_index     = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
-    MatcherGPU matcher(*query_index, *target_index);
+    std::unique_ptr<Index> query_index      = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> target_index     = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    MatcherGPU matcher(allocator, *query_index, *target_index);
 
-    const thrust::host_vector<Anchor> anchors(matcher.anchors());
+    thrust::host_vector<Anchor> anchors(matcher.anchors().size());
+    cudautils::device_copy_n(matcher.anchors().data(), matcher.anchors().size(), anchors.data()); // D2H
     ASSERT_EQ(get_size(anchors), 1);
 }
 
 TEST(TestCudamapperMatcherGPU, AtLeastOneIndexEmpty)
 {
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
     std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> index_full       = Index::create_index(*parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> index_empty      = Index::create_index(*parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
+    std::unique_ptr<Index> index_full       = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> index_empty      = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
 
     {
-        MatcherGPU matcher(*index_full, *index_empty);
-        const thrust::host_vector<Anchor> anchors(matcher.anchors());
+        MatcherGPU matcher(allocator, *index_full, *index_empty);
+        thrust::host_vector<Anchor> anchors(matcher.anchors().size());
+        cudautils::device_copy_n(matcher.anchors().data(), matcher.anchors().size(), anchors.data()); // D2H
         EXPECT_EQ(get_size(anchors), 0);
     }
     {
-        MatcherGPU matcher(*index_empty, *index_full);
-        const thrust::host_vector<Anchor> anchors(matcher.anchors());
+        MatcherGPU matcher(allocator, *index_empty, *index_full);
+        thrust::host_vector<Anchor> anchors(matcher.anchors().size());
+        cudautils::device_copy_n(matcher.anchors().data(), matcher.anchors().size(), anchors.data()); // D2H
         EXPECT_EQ(get_size(anchors), 0);
     }
     {
-        MatcherGPU matcher(*index_empty, *index_empty);
-        const thrust::host_vector<Anchor> anchors(matcher.anchors());
+        MatcherGPU matcher(allocator, *index_empty, *index_empty);
+        thrust::host_vector<Anchor> anchors(matcher.anchors().size());
+        cudautils::device_copy_n(matcher.anchors().data(), matcher.anchors().size(), anchors.data()); // D2H
         EXPECT_EQ(get_size(anchors), 0);
     }
     {
-        MatcherGPU matcher(*index_full, *index_full);
-        const thrust::host_vector<Anchor> anchors(matcher.anchors());
+        MatcherGPU matcher(allocator, *index_full, *index_full);
+        thrust::host_vector<Anchor> anchors(matcher.anchors().size());
+        cudautils::device_copy_n(matcher.anchors().data(), matcher.anchors().size(), anchors.data()); // D2H
         EXPECT_EQ(get_size(anchors), 1);
     }
 }

--- a/cudamapper/tests/Test_CudamapperMatcherGPU.cu
+++ b/cudamapper/tests/Test_CudamapperMatcherGPU.cu
@@ -29,7 +29,7 @@ void test_find_query_target_matches(const thrust::host_vector<representation_t>&
                                     const thrust::host_vector<representation_t>& target_representations_h,
                                     const thrust::host_vector<std::int64_t>& expected_found_target_indices_h)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     device_buffer<representation_t> query_representations_d(query_representations_h.size(), allocator);
     cudautils::device_copy_n(query_representations_h.data(), query_representations_h.size(), query_representations_d.data()); // H2D
     device_buffer<representation_t> target_representations_d(target_representations_h.size(), allocator);
@@ -110,7 +110,7 @@ void test_compute_number_of_anchors(const thrust::host_vector<std::uint32_t>& qu
                                     const thrust::host_vector<std::uint32_t>& target_starting_index_of_each_representation_h,
                                     const thrust::host_vector<std::int64_t>& expected_anchor_starting_indices_h)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     device_buffer<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h.size(), allocator);
     cudautils::device_copy_n(query_starting_index_of_each_representation_h.data(), query_starting_index_of_each_representation_h.size(), query_starting_index_of_each_representation_d.data()); //H2D
     device_buffer<std::uint32_t> target_starting_index_of_each_representation_d(target_starting_index_of_each_representation_h.size(), allocator);
@@ -209,7 +209,7 @@ void test_generate_anchors(
     const thrust::host_vector<read_id_t>& target_read_ids_h,
     const thrust::host_vector<position_in_read_t>& target_positions_in_read_h)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     device_buffer<std::int64_t> anchor_starting_indices_d(anchor_starting_indices_h.size(), allocator);
     cudautils::device_copy_n(anchor_starting_indices_h.data(), anchor_starting_indices_h.size(), anchor_starting_indices_d.data()); // H2D
     device_buffer<std::uint32_t> query_starting_index_of_each_representation_d(query_starting_index_of_each_representation_h.size(), allocator);
@@ -347,10 +347,10 @@ TEST(TestCudamapperMatcherGPU, test_generate_anchors_small_example)
 
 TEST(TestCudamapperMatcherGPU, OneReadOneMinimizer)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> query_index      = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> target_index     = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
+    std::unique_ptr<io::FastaParser> parser    = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
+    std::unique_ptr<Index> query_index         = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> target_index        = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
     MatcherGPU matcher(allocator, *query_index, *target_index);
 
     thrust::host_vector<Anchor> anchors(matcher.anchors().size());
@@ -360,10 +360,10 @@ TEST(TestCudamapperMatcherGPU, OneReadOneMinimizer)
 
 TEST(TestCudamapperMatcherGPU, AtLeastOneIndexEmpty)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
-    std::unique_ptr<io::FastaParser> parser = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
-    std::unique_ptr<Index> index_full       = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
-    std::unique_ptr<Index> index_empty      = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
+    std::unique_ptr<io::FastaParser> parser    = io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta");
+    std::unique_ptr<Index> index_full          = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 4, 1);
+    std::unique_ptr<Index> index_empty         = Index::create_index(allocator, *parser, 0, parser->get_num_seqences(), 5, 1); // kmer longer than read
 
     {
         MatcherGPU matcher(allocator, *index_full, *index_empty);

--- a/cudamapper/tests/Test_CudamapperMinimizer.cpp
+++ b/cudamapper/tests/Test_CudamapperMinimizer.cpp
@@ -26,19 +26,21 @@ void test_function(const std::uint64_t number_of_reads_to_add,
                    const std::vector<Minimizer::ReadidPositionDirection>& expected_rest_h,
                    const bool hash_minimizers)
 {
-    device_buffer<char> merged_basepairs_d(merged_basepairs_h.size());
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    device_buffer<char> merged_basepairs_d(merged_basepairs_h.size(), allocator);
     CGA_CU_CHECK_ERR(cudaMemcpy(merged_basepairs_d.data(),
                                 merged_basepairs_h.data(),
                                 merged_basepairs_h.size() * sizeof(char),
                                 cudaMemcpyHostToDevice));
 
-    device_buffer<ArrayBlock> read_id_to_basepairs_section_d(read_id_to_basepairs_section_h.size());
+    device_buffer<ArrayBlock> read_id_to_basepairs_section_d(read_id_to_basepairs_section_h.size(), allocator);
     CGA_CU_CHECK_ERR(cudaMemcpy(read_id_to_basepairs_section_d.data(),
                                 read_id_to_basepairs_section_h.data(),
                                 read_id_to_basepairs_section_h.size() * sizeof(ArrayBlock),
                                 cudaMemcpyHostToDevice));
 
-    auto sketch_elements = Minimizer::generate_sketch_elements(number_of_reads_to_add,
+    auto sketch_elements = Minimizer::generate_sketch_elements(allocator,
+                                                               number_of_reads_to_add,
                                                                minimizer_size,
                                                                window_size,
                                                                read_id_of_first_read,

--- a/cudamapper/tests/Test_CudamapperMinimizer.cpp
+++ b/cudamapper/tests/Test_CudamapperMinimizer.cpp
@@ -26,7 +26,7 @@ void test_function(const std::uint64_t number_of_reads_to_add,
                    const std::vector<Minimizer::ReadidPositionDirection>& expected_rest_h,
                    const bool hash_minimizers)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     device_buffer<char> merged_basepairs_d(merged_basepairs_h.size(), allocator);
     CGA_CU_CHECK_ERR(cudaMemcpy(merged_basepairs_d.data(),
                                 merged_basepairs_h.data(),

--- a/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
+++ b/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
@@ -24,7 +24,8 @@ namespace cudamapper
 
 TEST(TestCudamapperOverlapperTriggerred, FuseTwoOverlaps)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
 
@@ -54,7 +55,8 @@ TEST(TestCudamapperOverlapperTriggerred, FuseTwoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, DoNotuseTwoOverlaps)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
 
@@ -84,7 +86,8 @@ TEST(TestCudamapperOverlapperTriggerred, DoNotuseTwoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, OneOverlap)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
 
@@ -105,7 +108,8 @@ TEST(TestCudamapperOverlapperTriggerred, OneOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, NoOverlaps)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
 
@@ -117,7 +121,8 @@ TEST(TestCudamapperOverlapperTriggerred, NoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, Fusee3Overlapsto2)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
 
@@ -157,12 +162,13 @@ TEST(TestCudamapperOverlapperTriggerred, Fusee3Overlapsto2)
 
 TEST(TestCudamapperOverlapperTriggerred, OneAchorNoOverlaps)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -176,22 +182,25 @@ TEST(TestCudamapperOverlapperTriggerred, OneAchorNoOverlaps)
     }
 
     Anchor anchor1;
-
     anchors.push_back(anchor1);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -233,8 +242,11 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
     anchors.push_back(anchor3);
     anchors.push_back(anchor4);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_EQ(overlaps[0].query_read_id_, 1u);
     ASSERT_EQ(overlaps[0].target_read_id_, 2u);
@@ -246,12 +258,13 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -293,19 +306,23 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
     anchors.push_back(anchor3);
     anchors.push_back(anchor4);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
 TEST(TestCudamapperOverlapperTriggerred, FourColinearAnchorsOneOverlap)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -347,19 +364,23 @@ TEST(TestCudamapperOverlapperTriggerred, FourColinearAnchorsOneOverlap)
     anchors.push_back(anchor3);
     anchors.push_back(anchor4);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -401,8 +422,11 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
     anchors.push_back(anchor3);
     anchors.push_back(anchor4);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_EQ(overlaps[0].query_read_id_, 1u);
     ASSERT_EQ(overlaps[0].target_read_id_, 2u);
@@ -414,12 +438,13 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, ShuffledAnchors)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -470,13 +495,16 @@ TEST(TestCudamapperOverlapperTriggerred, ShuffledAnchors)
     anchors.push_back(anchor4);
     anchors.push_back(anchor5);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     auto rng = std::default_random_engine{};
     rng.seed(2);
     //Shuffle the anchors 100 times and check that the generated overlaps are always the same.
     for (size_t i = 0; i < 100; i++)
     {
         std::vector<Overlap> overlaps;
-        overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+        overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
         std::shuffle(std::begin(overlaps), std::end(overlaps), rng);
         ASSERT_EQ(overlaps.size(), 1u);
         ASSERT_EQ(overlaps[0].query_read_id_, 1u);
@@ -490,12 +518,13 @@ TEST(TestCudamapperOverlapperTriggerred, ShuffledAnchors)
 
 TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)
 {
-    OverlapperTriggered overlapper;
+    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
-    thrust::device_vector<Anchor> anchors;
+    std::vector<Anchor> anchors;
 
-    MockIndex test_index;
+    MockIndex test_index(allocator);
     std::vector<std::string> testv;
     testv.push_back("READ0");
     testv.push_back("READ1");
@@ -537,8 +566,11 @@ TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)
     anchors.push_back(anchor3);
     anchors.push_back(anchor4);
 
+    device_buffer<Anchor> anchors_d(anchors.size(), allocator);
+    cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
+
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_GT(overlaps[0].target_end_position_in_read_, overlaps[0].target_start_position_in_read_);
     ASSERT_EQ(overlaps[0].relative_strand, RelativeStrand::Reverse);

--- a/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
+++ b/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
@@ -24,7 +24,7 @@ namespace cudamapper
 
 TEST(TestCudamapperOverlapperTriggerred, FuseTwoOverlaps)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -55,7 +55,7 @@ TEST(TestCudamapperOverlapperTriggerred, FuseTwoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, DoNotuseTwoOverlaps)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -86,7 +86,7 @@ TEST(TestCudamapperOverlapperTriggerred, DoNotuseTwoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, OneOverlap)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -108,7 +108,7 @@ TEST(TestCudamapperOverlapperTriggerred, OneOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, NoOverlaps)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -121,7 +121,7 @@ TEST(TestCudamapperOverlapperTriggerred, NoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, Fusee3Overlapsto2)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -162,7 +162,7 @@ TEST(TestCudamapperOverlapperTriggerred, Fusee3Overlapsto2)
 
 TEST(TestCudamapperOverlapperTriggerred, OneAchorNoOverlaps)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -194,7 +194,7 @@ TEST(TestCudamapperOverlapperTriggerred, OneAchorNoOverlaps)
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -258,7 +258,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -316,7 +316,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, FourColinearAnchorsOneOverlap)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -374,7 +374,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourColinearAnchorsOneOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -438,7 +438,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
 
 TEST(TestCudamapperOverlapperTriggerred, ShuffledAnchors)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;
@@ -518,7 +518,7 @@ TEST(TestCudamapperOverlapperTriggerred, ShuffledAnchors)
 
 TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)
 {
-    std::shared_ptr<DeviceAllocator> allocator(new CudaMallocAllocator());
+    std::shared_ptr<DeviceAllocator> allocator = std::make_shared<CudaMallocAllocator>();
     OverlapperTriggered overlapper(allocator);
 
     std::vector<Overlap> unfused_overlaps;

--- a/cudamapper/tests/mock_index.cuh
+++ b/cudamapper/tests/mock_index.cuh
@@ -12,7 +12,6 @@
 
 #include "gmock/gmock.h"
 
-//#include <memory>
 #include <claragenomics/utils/cudautils.hpp>
 #include <claragenomics/utils/allocator.hpp>
 #include "../src/index_gpu.cuh"
@@ -29,7 +28,7 @@ class MockIndex : public IndexGPU<Minimizer>
 public:
     MockIndex(std::shared_ptr<DeviceAllocator> allocator)
         : IndexGPU(allocator,
-		   *claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta"),
+                   *claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta"),
                    0,
                    0,
                    0,

--- a/cudamapper/tests/mock_index.cuh
+++ b/cudamapper/tests/mock_index.cuh
@@ -12,6 +12,9 @@
 
 #include "gmock/gmock.h"
 
+//#include <memory>
+#include <claragenomics/utils/cudautils.hpp>
+#include <claragenomics/utils/allocator.hpp>
 #include "../src/index_gpu.cuh"
 #include "../src/minimizer.hpp"
 #include "cudamapper_file_location.hpp"
@@ -24,8 +27,9 @@ namespace cudamapper
 class MockIndex : public IndexGPU<Minimizer>
 {
 public:
-    MockIndex()
-        : IndexGPU(*claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta"),
+    MockIndex(std::shared_ptr<DeviceAllocator> allocator)
+        : IndexGPU(allocator,
+		   *claragenomics::io::create_fasta_parser(std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta"),
                    0,
                    0,
                    0,


### PR DESCRIPTION
This PR introduces the following
 - Add new device_buffer/host_buffer with allocator support. 
 - Use device_buffer in place of thrust::device_vector in indexer, matcher, and overlapper.
 - Use cub's caching allocator to manage device_buffer allocations in cudamapper. This is optional and can be turned off during build time (helps with debugging).
 - Add memory copy helper function.
 
Note that this PR adds device_buffer as a new module instead of replacing the existing one only to avoid any potential bugs in the pipeline outside of cudamapper. The device_buffer.hpp should eventually replace the existing device_buffer.cuh and will be used across all the modules of CGA.

Pending tasks -
- [ ] Update cudamapper tests. 
- [ ] Update default configuration of caching allocator based on performance study.

 