### PR TITLE
[cga] sort_by_two_keys

### DIFF
--- a/common/utils/include/claragenomics/utils/cudasort.cuh
+++ b/common/utils/include/claragenomics/utils/cudasort.cuh
@@ -47,7 +47,7 @@ namespace details
 /// \tparam ValueT
 template <typename KeyT,
           typename ValueT>
-void perform_radix_sort(thrust::device_vector<std::uint8_t> temp_storage_vect_d,
+void perform_radix_sort(thrust::device_vector<char>& temp_storage_vect_d,
                         const KeyT* unsorted_keys_d,
                         KeyT* sorted_keys_d,
                         const ValueT* unsorted_values_d,
@@ -112,8 +112,8 @@ void perform_radix_sort(thrust::device_vector<std::uint8_t> temp_storage_vect_d,
 /// \param more_significant_keys sorted on output
 /// \param less_significant_keys sorted on output
 /// \param values sorted on output
-/// \param max_value_of_more_significant_key optional, defaults to max value for MoreSignificantKeyT
-/// \param max_value_of_less_significant_key optional, defaults to max value for LessSignificantKeyT
+/// \param max_value_of_more_significant_key optional, defaults to max value for MoreSignificantKeyT (specifying it might lead to better performance)
+/// \param max_value_of_less_significant_key optional, defaults to max value for LessSignificantKeyT (specifying it might lead to better performance)
 /// \tparam MoreSignificantKeyT
 /// \tparam LessSignificantKeyT
 /// \tparam ValueT
@@ -153,7 +153,7 @@ void sort_by_two_keys(thrust::device_vector<MoreSignificantKeyT>& more_significa
     thrust::device_vector<LessSignificantKeyT> less_significant_key_sorted(number_of_elements);
     thrust::device_vector<move_to_index_t> move_to_index_sorted(number_of_elements);
 
-    thrust::device_vector<std::uint8_t> temp_storage_vect;
+    thrust::device_vector<char> temp_storage_vect;
 
     details::perform_radix_sort(temp_storage_vect,
                                 less_significant_keys.data().get(),
@@ -186,9 +186,7 @@ void sort_by_two_keys(thrust::device_vector<MoreSignificantKeyT>& more_significa
 
     // *** sort by more significant key ***
 
-    thrust::device_vector<std::uint8_t> temp_storage_vect_2;
-
-    details::perform_radix_sort(temp_storage_vect_2,
+    details::perform_radix_sort(temp_storage_vect,
                                 more_significant_keys.data().get(),
                                 more_significant_keys_after_sort.data().get(),
                                 move_to_index.data().get(),

--- a/common/utils/include/claragenomics/utils/cudasort.cuh
+++ b/common/utils/include/claragenomics/utils/cudasort.cuh
@@ -1,0 +1,198 @@
+/*
+* Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <stdexcept>
+
+#include <cub/cub.cuh>
+
+#include <thrust/device_vector.h>
+#include <thrust/execution_policy.h>
+#include <thrust/gather.h>
+#include <thrust/sequence.h>
+#include <thrust/swap.h>
+
+namespace claragenomics
+{
+namespace cudautils
+{
+namespace cudasort
+{
+namespace details
+{
+
+/// \brief Sorts key-value pairs using radix sort
+///
+/// \param temp_storage_vect_d temporary storage, may be empty, function uses it if it is large enough, reallocates otherwise
+/// \param unsorted_keys_d input
+/// \param sorted_keys_d output
+/// \param unsorted_values_d input
+/// \param sorted_values_d output
+/// \param number_of_elements number of elements to sort
+/// \tparam KeyT
+/// \tparam ValueT
+template <typename KeyT,
+          typename ValueT>
+void perform_radix_sort(thrust::device_vector<std::uint8_t> temp_storage_vect_d,
+                        const KeyT* unsorted_keys_d,
+                        KeyT* sorted_keys_d,
+                        const ValueT* unsorted_values_d,
+                        ValueT* sorted_values_d,
+                        int number_of_elements)
+{
+    // calculate necessary temp storage size
+    void* temp_storage_d      = nullptr;
+    size_t temp_storage_bytes = 0;
+    cub::DeviceRadixSort::SortPairs(temp_storage_d,
+                                    temp_storage_bytes, // <- this one gets changed
+                                    unsorted_keys_d,
+                                    sorted_keys_d,
+                                    unsorted_values_d,
+                                    sorted_values_d,
+                                    number_of_elements);
+
+    // allocate temp storage
+    if (temp_storage_bytes > temp_storage_vect_d.size())
+    {
+        temp_storage_vect_d.resize(temp_storage_bytes);
+    }
+    temp_storage_d     = static_cast<void*>(temp_storage_vect_d.data().get());
+    temp_storage_bytes = temp_storage_vect_d.size();
+
+    // perform actual sort
+    cub::DeviceRadixSort::SortPairs(temp_storage_d,
+                                    temp_storage_bytes,
+                                    unsorted_keys_d,
+                                    sorted_keys_d,
+                                    unsorted_values_d,
+                                    sorted_values_d,
+                                    number_of_elements);
+}
+
+} // namespace details
+
+/// \brief Sorts array by more significant key. Then sorts subarrays belonging to each more significiant key by less significant key
+///
+/// For example:
+/// ms_key ls_key value
+///      6      1     1
+///      2      4     2
+///      5      5     3
+///      4      5     4
+///      4      2     5
+///      2      1     6
+/// yields:
+///      2      1     6
+///      2      4     2
+///      4      2     5
+///      4      5     4
+///      5      5     3
+///      6      1     1
+///
+/// \param more_significant_keys sorted on output
+/// \param less_significant_keys sorted on output
+/// \param values sorted on output
+/// \tparam MoreSignificantKeyT
+/// \tparam LessSignificantKeyT
+/// \tparam ValueT
+template <typename MoreSignificantKeyT,
+          typename LessSignificantKeyT,
+          typename ValueT>
+void sort_by_two_keys(thrust::device_vector<MoreSignificantKeyT>& more_significant_keys,
+                      thrust::device_vector<LessSignificantKeyT>& less_significant_keys,
+                      thrust::device_vector<ValueT>& values)
+{
+    // Radix sort is done in-place, meaning sorting by less significant and then more significant keys yields the wanted result
+    //
+    // CUB's radix sort devides the key into chunks of a few bits (5-6?), sorts those bits and then moves to next (more significant) bits.
+    // That way it has only a few dozens of buckets in every step.
+    // A limitation of CUB's implementation is that it moves values to their new location in every step. If values are larger than 4 bytes this
+    // begins to dominate. That's why it's better to use a 32-bit index and move the values to the final location in the end.
+
+    // CUB accepts the number of elements as int, check if array is longer than that
+    // (this limitation can be avoided by some CUB trickery, but no need to do it here)
+    if (values.size() > std::numeric_limits<int>::max())
+    {
+        throw std::length_error("cudasort: array too long to be sorted");
+    }
+    using move_to_index_t = std::uint32_t;
+
+    const auto number_of_elements = values.size();
+
+    thrust::device_vector<move_to_index_t> move_to_index(number_of_elements);
+    // Fill array with values 0..number_of_elements-1
+    thrust::sequence(thrust::device,
+                     std::begin(move_to_index),
+                     std::end(move_to_index));
+
+    // *** sort by less significant key first ***
+    thrust::device_vector<LessSignificantKeyT> less_significant_key_sorted(number_of_elements);
+    thrust::device_vector<move_to_index_t> move_to_index_sorted(number_of_elements);
+
+    thrust::device_vector<std::uint8_t> temp_storage_vect;
+
+    details::perform_radix_sort(temp_storage_vect,
+                                less_significant_keys.data().get(),
+                                less_significant_key_sorted.data().get(),
+                                move_to_index.data().get(),
+                                move_to_index_sorted.data().get(),
+                                number_of_elements);
+
+    // swap sorted and unsorted arrays
+    thrust::swap(less_significant_keys, less_significant_key_sorted);
+    thrust::swap(move_to_index, move_to_index_sorted);
+
+    // deallocate helper array
+    // TODO: This array can probably be reused, but waiting for more general reallocation-avoidance strategy before optimizing this
+    less_significant_key_sorted.clear();
+    less_significant_key_sorted.shrink_to_fit();
+
+    // *** move more significant keys to their position after less significant keys sort ***
+    thrust::device_vector<MoreSignificantKeyT> more_significant_keys_after_sort(number_of_elements);
+
+    thrust::gather(thrust::device,
+                   std::begin(move_to_index),
+                   std::end(move_to_index),
+                   std::begin(more_significant_keys),
+                   std::begin(more_significant_keys_after_sort));
+
+    thrust::swap(more_significant_keys, more_significant_keys_after_sort);
+
+    // *** sort by more significant key ***
+
+    thrust::device_vector<std::uint8_t> temp_storage_vect_2;
+
+    details::perform_radix_sort(temp_storage_vect_2,
+                                more_significant_keys.data().get(),
+                                more_significant_keys_after_sort.data().get(),
+                                move_to_index.data().get(),
+                                move_to_index_sorted.data().get(),
+                                number_of_elements);
+
+    thrust::swap(move_to_index, move_to_index_sorted);
+
+    // *** move the values to their final position ***
+    thrust::device_vector<ValueT> values_after_sort(number_of_elements);
+
+    thrust::gather(thrust::device,
+                   std::begin(move_to_index),
+                   std::end(move_to_index),
+                   std::begin(values),
+                   std::begin(values_after_sort));
+
+    thrust::swap(values, values_after_sort);
+}
+
+} // namespace cudasort
+} // namespace cudautils
+} // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/cudasort.cuh
+++ b/common/utils/include/claragenomics/utils/cudasort.cuh
@@ -28,8 +28,6 @@ namespace claragenomics
 {
 namespace cudautils
 {
-namespace cudasort
-{
 namespace details
 {
 
@@ -209,6 +207,5 @@ void sort_by_two_keys(thrust::device_vector<MoreSignificantKeyT>& more_significa
     thrust::swap(values, values_after_sort);
 }
 
-} // namespace cudasort
 } // namespace cudautils
 } // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/mathutils.hpp
+++ b/common/utils/include/claragenomics/utils/mathutils.hpp
@@ -45,13 +45,8 @@ __host__ __device__ inline T const& min3(T const& t1, T const& t2, T const& t3)
 /// int_floor_log2(1) = 0
 /// int_floor_log2(2) = 1
 /// int_floor_log2(3) = 1
-/// int_floor_log2(4) = 2
-/// int_floor_log2(5) = 2
 /// int_floor_log2(8) = 3
 /// int_floor_log2(11) = 3
-/// int_floor_log2(16) = 4
-/// int_floor_log2(31) = 4
-/// int_floor_log2(32) = 5
 ///
 /// @param val
 /// @tparam T type of val
@@ -65,21 +60,6 @@ std::int32_t int_floor_log2(T val)
 
     std::int32_t power = 0;
     // keep dividing by 2 until value is 1
-    //
-    // for 11 = 0b1011 -> int_floor_log2(11) = 3
-    // value  power
-    // 0b1011 0
-    // 0b0101 1
-    // 0b0010 2
-    // 0b0001 3 <- this is returned
-    //
-    // for 16 = 0b10000 -> int_floor_log2 = 4
-    // value   power
-    // 0b10000 0
-    // 0b01000 1
-    // 0b00100 2
-    // 0b00010 3
-    // 0b00001 4 <- this is returned
     while (val != 1)
     {
         // divide by two, i.e. move by one log value

--- a/common/utils/include/claragenomics/utils/mathutils.hpp
+++ b/common/utils/include/claragenomics/utils/mathutils.hpp
@@ -55,7 +55,7 @@ std::int32_t int_floor_log2(T val)
 {
     static_assert(std::is_integral<T>::value, "Expected an integer");
 
-    assert (val <= 0);
+    assert(val <= 0);
 
     std::int32_t power = 0;
     // keep dividing by 2 until value is 1

--- a/common/utils/include/claragenomics/utils/mathutils.hpp
+++ b/common/utils/include/claragenomics/utils/mathutils.hpp
@@ -15,6 +15,7 @@
 #include <cuda_runtime_api.h>
 #ifndef __CUDA_ARCH__
 #include <algorithm>
+#include <stdexcept>
 #endif
 
 namespace claragenomics
@@ -37,6 +38,56 @@ __host__ __device__ inline T const& min3(T const& t1, T const& t2, T const& t3)
 #else
     return std::min(t1, std::min(t2, t3));
 #endif
+}
+
+/// @brief Calculates floor of log2() of the given integer number
+///
+/// int_floor_log2(1) = 0
+/// int_floor_log2(2) = 1
+/// int_floor_log2(3) = 1
+/// int_floor_log2(4) = 2
+/// int_floor_log2(5) = 2
+/// int_floor_log2(8) = 3
+/// int_floor_log2(11) = 3
+/// int_floor_log2(16) = 4
+/// int_floor_log2(31) = 4
+/// int_floor_log2(32) = 5
+///
+/// @param val
+/// @tparam T type of val
+template <typename T>
+std::int32_t int_floor_log2(T val)
+{
+    if (val <= 0)
+    {
+        throw std::invalid_argument("mathutils: only logarithms of positive numbers are defined");
+    }
+
+    std::int32_t power = 0;
+    // keep dividing by 2 until value is 1
+    //
+    // for 11 = 0b1011 -> int_floor_log2(11) = 3
+    // value  power
+    // 0b1011 0
+    // 0b0101 1
+    // 0b0010 2
+    // 0b0001 3 <- this is returned
+    //
+    // for 16 = 0b10000 -> int_floor_log2 = 4
+    // value   power
+    // 0b10000 0
+    // 0b01000 1
+    // 0b00100 2
+    // 0b00010 3
+    // 0b00001 4 <- this is returned
+    while (val != 1)
+    {
+        // divide by two, i.e. move by one log value
+        val >>= 1;
+        ++power;
+    }
+
+    return power;
 }
 
 } // namespace claragenomics

--- a/common/utils/include/claragenomics/utils/mathutils.hpp
+++ b/common/utils/include/claragenomics/utils/mathutils.hpp
@@ -11,11 +11,11 @@
 #pragma once
 
 #include <cassert>
+#include <cstdint>
 #include <type_traits>
 #include <cuda_runtime_api.h>
 #ifndef __CUDA_ARCH__
 #include <algorithm>
-#include <stdexcept>
 #endif
 
 namespace claragenomics
@@ -55,7 +55,7 @@ std::int32_t int_floor_log2(T val)
 {
     static_assert(std::is_integral<T>::value, "Expected an integer");
 
-    assert(val <= 0);
+    assert(val > 0);
 
     std::int32_t power = 0;
     // keep dividing by 2 until value is 1

--- a/common/utils/include/claragenomics/utils/mathutils.hpp
+++ b/common/utils/include/claragenomics/utils/mathutils.hpp
@@ -53,10 +53,9 @@ __host__ __device__ inline T const& min3(T const& t1, T const& t2, T const& t3)
 template <typename T>
 std::int32_t int_floor_log2(T val)
 {
-    if (val <= 0)
-    {
-        throw std::invalid_argument("mathutils: only logarithms of positive numbers are defined");
-    }
+    static_assert(std::is_integral<T>::value, "Expected an integer");
+
+    assert (val <= 0);
 
     std::int32_t power = 0;
     // keep dividing by 2 until value is 1

--- a/common/utils/tests/CMakeLists.txt
+++ b/common/utils/tests/CMakeLists.txt
@@ -10,6 +10,8 @@
 
 set(TARGET_NAME cgautilstests)
 
+set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -lineinfo -Xcompiler -Wall,-Wno-pedantic -std=c++14")
+
 set(SOURCES
     main.cpp
     Test_UtilsCudasort.cu

--- a/common/utils/tests/CMakeLists.txt
+++ b/common/utils/tests/CMakeLists.txt
@@ -12,7 +12,10 @@ set(TARGET_NAME cgautilstests)
 
 set(SOURCES
     main.cpp
+    Test_UtilsCudasort.cu
     TestGraph.cpp)
+
+include_directories(${CUB_DIR})
 
 set(LIBS
     utils)

--- a/common/utils/tests/Test_UtilsCudasort.cu
+++ b/common/utils/tests/Test_UtilsCudasort.cu
@@ -22,8 +22,6 @@
 
 namespace claragenomics
 {
-namespace cudautils
-{
 
 template <typename MoreSignificantKeyT,
           typename LessSignificantKeyT,
@@ -37,11 +35,11 @@ void test_function(thrust::device_vector<MoreSignificantKeyT>& more_significant_
     ASSERT_EQ(input_values.size(), more_significant_keys.size());
     ASSERT_EQ(input_values.size(), less_significant_keys.size());
 
-    sort_by_two_keys(more_significant_keys,
-                     less_significant_keys,
-                     input_values,
-                     max_value_of_more_significant_key,
-                     max_value_of_less_significant_key);
+    cudautils::sort_by_two_keys(more_significant_keys,
+                                less_significant_keys,
+                                input_values,
+                                max_value_of_more_significant_key,
+                                max_value_of_less_significant_key);
 
     thrust::host_vector<ValueT> sorted_values_h(input_values);
 
@@ -224,5 +222,4 @@ TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
                   max_value_of_less_significant_key);
 }
 
-} //namespace cudautils
 } //namespace claragenomics

--- a/common/utils/tests/Test_UtilsCudasort.cu
+++ b/common/utils/tests/Test_UtilsCudasort.cu
@@ -34,14 +34,18 @@ template <typename MoreSignificantKeyT,
           typename ValueT>
 void test_function(thrust::device_vector<MoreSignificantKeyT>& more_significant_keys,
                    thrust::device_vector<LessSignificantKeyT>& less_significant_keys,
-                   thrust::device_vector<ValueT>& input_values)
+                   thrust::device_vector<ValueT>& input_values,
+                   const MoreSignificantKeyT max_value_of_more_significant_key,
+                   const LessSignificantKeyT max_value_of_less_significant_key)
 {
     ASSERT_EQ(input_values.size(), more_significant_keys.size());
     ASSERT_EQ(input_values.size(), less_significant_keys.size());
 
     sort_by_two_keys(more_significant_keys,
                      less_significant_keys,
-                     input_values);
+                     input_values,
+                     max_value_of_more_significant_key,
+                     max_value_of_less_significant_key);
 
     thrust::host_vector<ValueT> sorted_values_h(input_values);
 
@@ -53,29 +57,34 @@ void test_function(thrust::device_vector<MoreSignificantKeyT>& more_significant_
     }
 }
 
-// repreat this test with differnt combinations of types
+// repreat this test with differnt combinations of types, more significant key has larger max value than less significant key
 template <typename MoreSignificantKeyT,
           typename LessSignificantKeyT,
           typename ValueT>
-void short_test_template()
+void short_test_template_larger_more_significant_key()
 {
     // more less value
-    //    6    1     610
-    //    2    4     240
-    //    5    5     550
-    //    4    2     420
-    //    4    5     450
-    //    2    1     210
-    //    2    2     220
-    //    3    8     380
-    //    3    7     370
-    //    5    1     510
-    //    5    3     530
-    //    4    5     451
-    //    8    4     840
-    const std::vector<MoreSignificantKeyT> more_significant_keys_vec = {6, 2, 5, 4, 4, 2, 2, 3, 3, 5, 5, 4, 8};
+    //   60   1   610
+    //   20   4   240
+    //   50   5   550
+    //   40   2   420
+    //   40   5   450
+    //   20   1   210
+    //   20   2   220
+    //   30   8   380
+    //   30   7   370
+    //   50   1   510
+    //   50   3   530
+    //   40   5   451
+    //   80   4   840
+    const std::vector<MoreSignificantKeyT> more_significant_keys_vec = {60, 20, 50, 40, 40, 20, 20, 30, 30, 50, 50, 40, 80};
     const std::vector<LessSignificantKeyT> less_significant_keys_vec = {1, 4, 5, 2, 5, 1, 2, 8, 7, 1, 3, 5, 4};
     const std::vector<ValueT> input_values_vec                       = {610, 240, 550, 420, 450, 210, 220, 380, 370, 510, 530, 451, 840};
+
+    const MoreSignificantKeyT max_value_of_more_significant_key = *std::max_element(std::begin(more_significant_keys_vec),
+                                                                                    std::end(more_significant_keys_vec));
+    const LessSignificantKeyT max_value_of_less_significant_key = *std::max_element(std::begin(less_significant_keys_vec),
+                                                                                    std::end(less_significant_keys_vec));
 
     thrust::device_vector<MoreSignificantKeyT> more_significant_keys(std::begin(more_significant_keys_vec),
                                                                      std::end(more_significant_keys_vec));
@@ -86,47 +95,100 @@ void short_test_template()
 
     test_function(more_significant_keys,
                   less_significant_keys,
-                  input_values);
+                  input_values,
+                  max_value_of_more_significant_key,
+                  max_value_of_less_significant_key);
+}
+
+// repreat this test with differnt combinations of types, less significant key has larger max value than more significant key
+template <typename MoreSignificantKeyT,
+          typename LessSignificantKeyT,
+          typename ValueT>
+void short_test_template_larger_less_significant_key()
+{
+    // more less value
+    //    6   10   610
+    //    2   40   240
+    //    5   50   550
+    //    4   20   420
+    //    4   50   450
+    //    2   10   210
+    //    2   20   220
+    //    3   80   380
+    //    3   70   370
+    //    5   10   510
+    //    5   30   530
+    //    4   50   451
+    //    8   40   840
+    const std::vector<MoreSignificantKeyT> more_significant_keys_vec = {6, 2, 5, 4, 4, 2, 2, 3, 3, 5, 5, 4, 8};
+    const std::vector<LessSignificantKeyT> less_significant_keys_vec = {10, 40, 50, 20, 50, 10, 20, 80, 70, 10, 30, 50, 40};
+    const std::vector<ValueT> input_values_vec                       = {610, 240, 550, 420, 450, 210, 220, 380, 370, 510, 530, 451, 840};
+
+    const MoreSignificantKeyT max_value_of_more_significant_key = *std::max_element(std::begin(more_significant_keys_vec),
+                                                                                    std::end(more_significant_keys_vec));
+    const LessSignificantKeyT max_value_of_less_significant_key = *std::max_element(std::begin(less_significant_keys_vec),
+                                                                                    std::end(less_significant_keys_vec));
+
+    thrust::device_vector<MoreSignificantKeyT> more_significant_keys(std::begin(more_significant_keys_vec),
+                                                                     std::end(more_significant_keys_vec));
+    thrust::device_vector<LessSignificantKeyT> less_significant_keys(std::begin(less_significant_keys_vec),
+                                                                     std::end(less_significant_keys_vec));
+    thrust::device_vector<ValueT> input_values(std::begin(input_values_vec),
+                                               std::end(input_values_vec));
+
+    test_function(more_significant_keys,
+                  less_significant_keys,
+                  input_values,
+                  max_value_of_more_significant_key,
+                  max_value_of_less_significant_key);
 }
 
 TEST(TestUtilsCudasort, short_32_32_32_test)
 {
-    short_test_template<std::uint32_t, std::uint32_t, std::uint32_t>();
+    short_test_template_larger_more_significant_key<std::uint32_t, std::uint32_t, std::uint32_t>();
+    short_test_template_larger_less_significant_key<std::uint32_t, std::uint32_t, std::uint32_t>();
 }
 
 TEST(TestUtilsCudasort, short_32_32_64_test)
 {
-    short_test_template<std::uint32_t, std::uint32_t, std::uint64_t>();
+    short_test_template_larger_more_significant_key<std::uint32_t, std::uint32_t, std::uint64_t>();
+    short_test_template_larger_less_significant_key<std::uint32_t, std::uint32_t, std::uint64_t>();
 }
 
 TEST(TestUtilsCudasort, short_32_64_32_test)
 {
-    short_test_template<std::uint32_t, std::uint64_t, std::uint32_t>();
+    short_test_template_larger_more_significant_key<std::uint32_t, std::uint64_t, std::uint32_t>();
+    short_test_template_larger_less_significant_key<std::uint32_t, std::uint64_t, std::uint32_t>();
 }
 
 TEST(TestUtilsCudasort, short_32_64_64_test)
 {
-    short_test_template<std::uint32_t, std::uint64_t, std::uint64_t>();
+    short_test_template_larger_more_significant_key<std::uint32_t, std::uint64_t, std::uint64_t>();
+    short_test_template_larger_less_significant_key<std::uint32_t, std::uint64_t, std::uint64_t>();
 }
 
 TEST(TestUtilsCudasort, short_64_32_32_test)
 {
-    short_test_template<std::uint64_t, std::uint32_t, std::uint32_t>();
+    short_test_template_larger_more_significant_key<std::uint64_t, std::uint32_t, std::uint32_t>();
+    short_test_template_larger_less_significant_key<std::uint64_t, std::uint32_t, std::uint32_t>();
 }
 
 TEST(TestUtilsCudasort, short_64_32_64_test)
 {
-    short_test_template<std::uint64_t, std::uint32_t, std::uint64_t>();
+    short_test_template_larger_more_significant_key<std::uint64_t, std::uint32_t, std::uint64_t>();
+    short_test_template_larger_less_significant_key<std::uint64_t, std::uint32_t, std::uint64_t>();
 }
 
 TEST(TestUtilsCudasort, short_64_64_32_test)
 {
-    short_test_template<std::uint64_t, std::uint64_t, std::uint32_t>();
+    short_test_template_larger_more_significant_key<std::uint64_t, std::uint64_t, std::uint32_t>();
+    short_test_template_larger_less_significant_key<std::uint64_t, std::uint64_t, std::uint32_t>();
 }
 
 TEST(TestUtilsCudasort, short_64_64_64_test)
 {
-    short_test_template<std::uint64_t, std::uint64_t, std::uint64_t>();
+    short_test_template_larger_more_significant_key<std::uint64_t, std::uint64_t, std::uint64_t>();
+    short_test_template_larger_less_significant_key<std::uint64_t, std::uint64_t, std::uint64_t>();
 }
 
 TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
@@ -157,7 +219,14 @@ TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
                    });
     thrust::device_vector<std::uint64_t> input_values_d(input_values_h);
 
-    test_function(more_significant_keys_d, less_significant_keys_d, input_values_d);
+    const std::uint32_t max_value_of_more_significant_key = number_of_elements - 1;
+    const std::uint32_t max_value_of_less_significant_key = number_of_elements - 1;
+
+    test_function(more_significant_keys_d,
+                  less_significant_keys_d,
+                  input_values_d,
+                  max_value_of_more_significant_key,
+                  max_value_of_less_significant_key);
 }
 
 } //namespace tests

--- a/common/utils/tests/Test_UtilsCudasort.cu
+++ b/common/utils/tests/Test_UtilsCudasort.cu
@@ -24,10 +24,6 @@ namespace claragenomics
 {
 namespace cudautils
 {
-namespace cudasort
-{
-namespace tests
-{
 
 template <typename MoreSignificantKeyT,
           typename LessSignificantKeyT,
@@ -228,7 +224,5 @@ TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
                   max_value_of_less_significant_key);
 }
 
-} //namespace tests
-} //namespace cudasort
 } //namespace cudautils
 } //namespace claragenomics

--- a/common/utils/tests/Test_UtilsCudasort.cu
+++ b/common/utils/tests/Test_UtilsCudasort.cu
@@ -1,0 +1,166 @@
+/*
+* Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#include "gtest/gtest.h"
+
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <vector>
+
+#include <thrust/device_vector.h>
+#include <thrust/host_vector.h>
+
+#include "../include/claragenomics/utils/cudasort.cuh"
+
+namespace claragenomics
+{
+namespace cudautils
+{
+namespace cudasort
+{
+namespace tests
+{
+
+template <typename MoreSignificantKeyT,
+          typename LessSignificantKeyT,
+          typename ValueT>
+void test_function(thrust::device_vector<MoreSignificantKeyT>& more_significant_keys,
+                   thrust::device_vector<LessSignificantKeyT>& less_significant_keys,
+                   thrust::device_vector<ValueT>& input_values)
+{
+    ASSERT_EQ(input_values.size(), more_significant_keys.size());
+    ASSERT_EQ(input_values.size(), less_significant_keys.size());
+
+    sort_by_two_keys(more_significant_keys,
+                     less_significant_keys,
+                     input_values);
+
+    thrust::host_vector<ValueT> sorted_values_h(input_values);
+
+    ASSERT_EQ(sorted_values_h.size(), input_values.size());
+    // sort is done by two keys and not values, but tests cases are intentionally made so the values are sorted as well
+    for (std::size_t i = 1; i < input_values.size(); ++i)
+    {
+        EXPECT_LE(sorted_values_h[i - 1], sorted_values_h[i]) << "index: " << i << std::endl;
+    }
+}
+
+// repreat this test with differnt combinations of types
+template <typename MoreSignificantKeyT,
+          typename LessSignificantKeyT,
+          typename ValueT>
+void short_test_template()
+{
+    // more less value
+    //    6    1     610
+    //    2    4     240
+    //    5    5     550
+    //    4    2     420
+    //    4    5     450
+    //    2    1     210
+    //    2    2     220
+    //    3    8     380
+    //    3    7     370
+    //    5    1     510
+    //    5    3     530
+    //    4    5     451
+    //    8    4     840
+    const std::vector<MoreSignificantKeyT> more_significant_keys_vec = {6, 2, 5, 4, 4, 2, 2, 3, 3, 5, 5, 4, 8};
+    const std::vector<LessSignificantKeyT> less_significant_keys_vec = {1, 4, 5, 2, 5, 1, 2, 8, 7, 1, 3, 5, 4};
+    const std::vector<ValueT> input_values_vec                       = {610, 240, 550, 420, 450, 210, 220, 380, 370, 510, 530, 451, 840};
+
+    thrust::device_vector<MoreSignificantKeyT> more_significant_keys(std::begin(more_significant_keys_vec),
+                                                                     std::end(more_significant_keys_vec));
+    thrust::device_vector<LessSignificantKeyT> less_significant_keys(std::begin(less_significant_keys_vec),
+                                                                     std::end(less_significant_keys_vec));
+    thrust::device_vector<ValueT> input_values(std::begin(input_values_vec),
+                                               std::end(input_values_vec));
+
+    test_function(more_significant_keys,
+                  less_significant_keys,
+                  input_values);
+}
+
+TEST(TestUtilsCudasort, short_32_32_32_test)
+{
+    short_test_template<std::uint32_t, std::uint32_t, std::uint32_t>();
+}
+
+TEST(TestUtilsCudasort, short_32_32_64_test)
+{
+    short_test_template<std::uint32_t, std::uint32_t, std::uint64_t>();
+}
+
+TEST(TestUtilsCudasort, short_32_64_32_test)
+{
+    short_test_template<std::uint32_t, std::uint64_t, std::uint32_t>();
+}
+
+TEST(TestUtilsCudasort, short_32_64_64_test)
+{
+    short_test_template<std::uint32_t, std::uint64_t, std::uint64_t>();
+}
+
+TEST(TestUtilsCudasort, short_64_32_32_test)
+{
+    short_test_template<std::uint64_t, std::uint32_t, std::uint32_t>();
+}
+
+TEST(TestUtilsCudasort, short_64_32_64_test)
+{
+    short_test_template<std::uint64_t, std::uint32_t, std::uint64_t>();
+}
+
+TEST(TestUtilsCudasort, short_64_64_32_test)
+{
+    short_test_template<std::uint64_t, std::uint64_t, std::uint32_t>();
+}
+
+TEST(TestUtilsCudasort, short_64_64_64_test)
+{
+    short_test_template<std::uint64_t, std::uint64_t, std::uint64_t>();
+}
+
+TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
+{
+    std::size_t number_of_elements = 10'000'000;
+
+    std::random_device rd;
+    std::mt19937 g(rd());
+
+    // fill the arrays with values 0..number_of_elements and shuffle them
+    thrust::host_vector<std::uint32_t> more_significant_keys_h(number_of_elements);
+    std::iota(std::begin(more_significant_keys_h), std::end(more_significant_keys_h), 0);
+    std::shuffle(std::begin(more_significant_keys_h), std::end(more_significant_keys_h), g);
+    thrust::device_vector<std::uint32_t> more_significant_keys_d(more_significant_keys_h);
+
+    thrust::host_vector<std::uint32_t> less_significant_keys_h(number_of_elements);
+    std::iota(std::begin(less_significant_keys_h), std::end(less_significant_keys_h), 0);
+    std::shuffle(std::begin(less_significant_keys_h), std::end(less_significant_keys_h), g);
+    thrust::device_vector<std::uint32_t> less_significant_keys_d(less_significant_keys_h);
+
+    thrust::host_vector<std::uint64_t> input_values_h(number_of_elements);
+    std::transform(std::begin(more_significant_keys_h),
+                   std::end(more_significant_keys_h),
+                   std::begin(less_significant_keys_h),
+                   std::begin(input_values_h),
+                   [number_of_elements](const std::uint32_t more_significant_key, const std::uint32_t less_significant_key) {
+                       return number_of_elements * more_significant_key + less_significant_key;
+                   });
+    thrust::device_vector<std::uint64_t> input_values_d(input_values_h);
+
+    test_function(more_significant_keys_d, less_significant_keys_d, input_values_d);
+}
+
+} //namespace tests
+} //namespace cudasort
+} //namespace cudautils
+} //namespace claragenomics

--- a/common/utils/tests/Test_UtilsCudasort.cu
+++ b/common/utils/tests/Test_UtilsCudasort.cu
@@ -18,7 +18,7 @@
 #include <thrust/device_vector.h>
 #include <thrust/host_vector.h>
 
-#include "../include/claragenomics/utils/cudasort.cuh"
+#include <claragenomics/utils/cudasort.cuh>
 
 namespace claragenomics
 {
@@ -193,10 +193,9 @@ TEST(TestUtilsCudasort, short_64_64_64_test)
 
 TEST(TestUtilsCudasort, long_deterministic_shuffle_test)
 {
-    std::size_t number_of_elements = 10'000'000;
+    std::int64_t number_of_elements = 10'000'000;
 
-    std::random_device rd;
-    std::mt19937 g(rd());
+    std::mt19937 g(10);
 
     // fill the arrays with values 0..number_of_elements and shuffle them
     thrust::host_vector<std::uint32_t> more_significant_keys_h(number_of_elements);


### PR DESCRIPTION
Function takes two keys are sorts the values by both of them.

This will be needed for fast sorting of anchors.

See #265 