### PR TITLE
[cudamapper] Overlapper gaps

### DIFF
--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -48,7 +48,8 @@ add_library(cudamapper_utils
 target_include_directories(cudamapper_utils PUBLIC include)
 
 cuda_add_library(overlapper_triggerred
-        src/overlapper_triggered.cu)
+        src/overlapper_triggered.cu
+        src/overlapper.cpp)
 target_include_directories(overlapper_triggerred PUBLIC include ${CUB_DIR})
 target_link_libraries(overlapper_triggerred logging utils cgaio)
 target_compile_options(overlapper_triggerred PRIVATE -Werror)

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -32,13 +32,9 @@ public:
 
     /// \brief returns overlaps for a set of reads
     /// \param overlaps Output vector into which generated overlaps will be placed
-    /// \param anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
-    /// \param index_query
-    /// \param index_target
-    virtual void get_overlaps(std::vector<Overlap>& overlaps,
-                              device_buffer<Anchor>& anchors,
-                              const Index& index_query,
-                              const Index& index_target) = 0;
+    /// \param anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read
+    /// (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
+    virtual void get_overlaps(std::vector<Overlap> &overlaps, device_buffer <Anchor> &anchors) = 0;
 
     /// \brief prints overlaps to stdout in <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">PAF format</a>
     static void print_paf(const std::vector<Overlap>& overlaps);

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -32,10 +32,9 @@ public:
     virtual ~Overlapper() = default;
 
     /// \brief returns overlaps for a set of reads
-    /// \param overlaps Output vector into which generated overlaps will be placed
-    /// \param anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read
-    /// (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
-    virtual void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors) = 0;
+    /// \param fused_overlaps Output vector into which generated overlaps will be placed
+    /// \param d_anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
+    virtual void get_overlaps(std::vector<Overlap>& fused_overlaps, device_buffer<Anchor>& d_anchors) = 0;
 
     /// \brief prints overlaps to stdout in <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">PAF format</a>
     static void print_paf(const std::vector<Overlap>& overlaps);

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -52,6 +52,14 @@ public:
                                 const std::vector<Overlap>& overlaps,
                                 size_t min_residues    = 20,
                                 size_t min_overlap_len = 50);
+
+    /// \brief updates read names for vector of overlaps output from get_overlaps
+    /// \param overlaps input vector of overlaps generated in get_overlaps
+    /// \param index_query
+    /// \param index_target
+    static void update_read_names(std::vector<Overlap>& overlaps,
+                                  const Index& index_query,
+                                  const Index& index_target);
 };
 //}
 } // namespace cudamapper

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -34,7 +34,7 @@ public:
     /// \param overlaps Output vector into which generated overlaps will be placed
     /// \param anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read
     /// (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
-    virtual void get_overlaps(std::vector<Overlap> &overlaps, device_buffer <Anchor> &anchors) = 0;
+    virtual void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors) = 0;
 
     /// \brief prints overlaps to stdout in <a href="https://github.com/lh3/miniasm/blob/master/PAF.md">PAF format</a>
     static void print_paf(const std::vector<Overlap>& overlaps);

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -315,11 +315,16 @@ int main(int argc, char* argv[])
                 // Get unfiltered overlaps
                 auto overlaps_to_add = std::make_shared<std::vector<claragenomics::cudamapper::Overlap>>();
 
-                overlapper.get_overlaps(*overlaps_to_add, matcher->anchors(), *query_index, *target_index);
+                overlapper.get_overlaps(*overlaps_to_add, matcher->anchors());
 
                 //Increment counter which tracks number of overlap chunks to be filtered and printed
                 num_overlap_chunks_to_print++;
-                auto filter_and_print_overlaps = [&overlaps_writer_mtx, &num_overlap_chunks_to_print](std::shared_ptr<std::vector<claragenomics::cudamapper::Overlap>> overlaps) {
+                auto filter_and_print_overlaps = [&overlaps_writer_mtx, &num_overlap_chunks_to_print](std::shared_ptr<std::vector<claragenomics::cudamapper::Overlap>> overlaps,
+                                                                                                      std::shared_ptr<claragenomics::cudamapper::Index> query_index,
+                                                                                                      std::shared_ptr<claragenomics::cudamapper::Index> target_index)
+                {
+                    // parallel update the overlaps to include the corresponding read names [parallel on host]
+                    claragenomics::cudamapper::Overlapper::update_read_names(*overlaps, *query_index, *target_index);
                     std::vector<claragenomics::cudamapper::Overlap> filtered_overlaps;
                     claragenomics::cudamapper::Overlapper::filter_overlaps(filtered_overlaps, *overlaps, 50);
                     std::lock_guard<std::mutex> lck(overlaps_writer_mtx);
@@ -334,7 +339,7 @@ int main(int argc, char* argv[])
                     num_overlap_chunks_to_print--;
                 };
 
-                std::thread t(filter_and_print_overlaps, overlaps_to_add);
+                std::thread t(filter_and_print_overlaps, overlaps_to_add, query_index, target_index);
                 t.detach();
             }
             // reseting the matcher releases the anchor device array back to memory pool

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -321,12 +321,11 @@ int main(int argc, char* argv[])
                 num_overlap_chunks_to_print++;
                 auto filter_and_print_overlaps = [&overlaps_writer_mtx, &num_overlap_chunks_to_print](std::shared_ptr<std::vector<claragenomics::cudamapper::Overlap>> overlaps,
                                                                                                       std::shared_ptr<claragenomics::cudamapper::Index> query_index,
-                                                                                                      std::shared_ptr<claragenomics::cudamapper::Index> target_index)
-                {
-                    // parallel update the overlaps to include the corresponding read names [parallel on host]
-                    claragenomics::cudamapper::Overlapper::update_read_names(*overlaps, *query_index, *target_index);
+                                                                                                      std::shared_ptr<claragenomics::cudamapper::Index> target_index) {
                     std::vector<claragenomics::cudamapper::Overlap> filtered_overlaps;
                     claragenomics::cudamapper::Overlapper::filter_overlaps(filtered_overlaps, *overlaps, 50);
+                    // parallel update of the query/target read names for filtered overlaps [parallel on host]
+                    claragenomics::cudamapper::Overlapper::update_read_names(filtered_overlaps, *query_index, *target_index);
                     std::lock_guard<std::mutex> lck(overlaps_writer_mtx);
                     claragenomics::cudamapper::Overlapper::print_paf(filtered_overlaps);
 

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
                     num_overlap_chunks_to_print--;
                 };
 
-                std::thread t(filter_and_print_overlaps, overlaps_to_add);
+                std::thread t(filter_and_print_overlaps, std::move(overlaps_to_add));
                 t.detach();
             }
             // reseting the matcher releases the anchor device array back to memory pool

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -313,20 +313,20 @@ int main(int argc, char* argv[])
                 CGA_NVTX_RANGE(profiler, "generate_overlaps");
 
                 // Get unfiltered overlaps
-                std::vector<claragenomics::cudamapper::Overlap> overlaps_to_add;
+                auto overlaps_to_add = std::make_shared<std::vector<claragenomics::cudamapper::Overlap>>();
 
-                overlapper.get_overlaps(overlaps_to_add, matcher->anchors(), *query_index, *target_index);
+                overlapper.get_overlaps(*overlaps_to_add, matcher->anchors(), *query_index, *target_index);
 
                 //Increment counter which tracks number of overlap chunks to be filtered and printed
                 num_overlap_chunks_to_print++;
-                auto filter_and_print_overlaps = [&overlaps_writer_mtx, &num_overlap_chunks_to_print](std::vector<claragenomics::cudamapper::Overlap> overlaps) {
+                auto filter_and_print_overlaps = [&overlaps_writer_mtx, &num_overlap_chunks_to_print](std::shared_ptr<std::vector<claragenomics::cudamapper::Overlap>> overlaps) {
                     std::vector<claragenomics::cudamapper::Overlap> filtered_overlaps;
-                    claragenomics::cudamapper::Overlapper::filter_overlaps(filtered_overlaps, overlaps, 50);
+                    claragenomics::cudamapper::Overlapper::filter_overlaps(filtered_overlaps, *overlaps, 50);
                     std::lock_guard<std::mutex> lck(overlaps_writer_mtx);
                     claragenomics::cudamapper::Overlapper::print_paf(filtered_overlaps);
 
                     //clear data
-                    for (auto o : overlaps)
+                    for (auto o : *overlaps)
                     {
                         o.clear();
                     }
@@ -334,7 +334,7 @@ int main(int argc, char* argv[])
                     num_overlap_chunks_to_print--;
                 };
 
-                std::thread t(filter_and_print_overlaps, std::move(overlaps_to_add));
+                std::thread t(filter_and_print_overlaps, overlaps_to_add);
                 t.detach();
             }
             // reseting the matcher releases the anchor device array back to memory pool

--- a/cudamapper/src/overlapper.cpp
+++ b/cudamapper/src/overlapper.cpp
@@ -39,14 +39,14 @@ void Overlapper::update_read_names(std::vector<Overlap>& overlaps,
 #pragma omp parallel for
     for (size_t i = 0; i < overlaps.size(); i++)
     {
-        auto& o                      = overlaps[i];
-        std::string query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
-        std::string target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
+        auto& o                             = overlaps[i];
+        const std::string& query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
+        const std::string& target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
 
-        o.query_read_name_ = new char[query_read_name.length()];
+        o.query_read_name_ = new char[query_read_name.length() + 1];
         strcpy(o.query_read_name_, query_read_name.c_str());
 
-        o.target_read_name_ = new char[target_read_name.length()];
+        o.target_read_name_ = new char[target_read_name.length() + 1];
         strcpy(o.target_read_name_, target_read_name.c_str());
 
         o.query_length_  = index_query.read_id_to_read_length(o.query_read_id_);

--- a/cudamapper/src/overlapper.cpp
+++ b/cudamapper/src/overlapper.cpp
@@ -32,6 +32,28 @@ void Overlapper::filter_overlaps(std::vector<Overlap>& filtered_overlaps, const 
                  valid_overlap);
 }
 
+void Overlapper::update_read_names(std::vector<Overlap>& fused_overlaps,
+                                   const Index& index_query,
+                                   const Index& index_target)
+{
+#pragma omp parallel for
+    for (size_t i = 0; i < fused_overlaps.size(); i++)
+    {
+        auto& o                      = fused_overlaps[i];
+        std::string query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
+        std::string target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
+
+        o.query_read_name_ = new char[query_read_name.length()];
+        strcpy(o.query_read_name_, query_read_name.c_str());
+
+        o.target_read_name_ = new char[target_read_name.length()];
+        strcpy(o.target_read_name_, target_read_name.c_str());
+
+        o.query_length_  = index_query.read_id_to_read_length(o.query_read_id_);
+        o.target_length_ = index_target.read_id_to_read_length(o.target_read_id_);
+    }
+}
+
 void Overlapper::print_paf(const std::vector<Overlap>& overlaps)
 {
     for (const auto& overlap : overlaps)

--- a/cudamapper/src/overlapper.cpp
+++ b/cudamapper/src/overlapper.cpp
@@ -23,7 +23,7 @@ void Overlapper::filter_overlaps(std::vector<Overlap>& filtered_overlaps, const 
                                                                                   (overlap.num_residues_ >= min_residues) &&
                                                                                   ((overlap.query_end_position_in_read_ - overlap.query_start_position_in_read_) > min_overlap_len) &&
                                                                                   !( // Reject overlaps where the query and target sections are exactly the same, otherwise miniasm has trouble.
-                                                                                      (std::string(overlap.query_read_name_) == std::string(overlap.target_read_name_)) &&
+                                                                                      overlap.query_read_id_ == overlap.target_read_id_ &&
                                                                                       overlap.query_start_position_in_read_ == overlap.target_start_position_in_read_ &&
                                                                                       overlap.query_end_position_in_read_ == overlap.target_end_position_in_read_)); };
 
@@ -32,14 +32,14 @@ void Overlapper::filter_overlaps(std::vector<Overlap>& filtered_overlaps, const 
                  valid_overlap);
 }
 
-void Overlapper::update_read_names(std::vector<Overlap>& fused_overlaps,
+void Overlapper::update_read_names(std::vector<Overlap>& overlaps,
                                    const Index& index_query,
                                    const Index& index_target)
 {
 #pragma omp parallel for
-    for (size_t i = 0; i < fused_overlaps.size(); i++)
+    for (size_t i = 0; i < overlaps.size(); i++)
     {
-        auto& o                      = fused_overlaps[i];
+        auto& o                      = overlaps[i];
         std::string query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
         std::string target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
 

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -196,10 +196,7 @@ OverlapperTriggered::~OverlapperTriggered()
     CGA_CU_CHECK_ERR(cudaStreamDestroy(stream));
 }
 
-void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
-                                       device_buffer<Anchor>& d_anchors,
-                                       const Index& index_query,
-                                       const Index& index_target)
+void OverlapperTriggered::get_overlaps(std::vector<Overlap> &fused_overlaps, device_buffer <Anchor> &d_anchors)
 {
     CGA_NVTX_RANGE(profiler, "OverlapperTriggered::get_overlaps");
     const auto tail_length_for_chain = 3;
@@ -376,9 +373,6 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
     cudautils::device_copy_n(d_fused_overlaps.data(), n_fused_overlap, fused_overlaps.data(), stream);
     CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
 
-    // <<<<<<<<<<<<
-    // parallel update the overlaps to include the corresponding read names [parallel on host]
-    Overlapper::update_read_names(fused_overlaps, index_query, index_target);
 }
 
 } // namespace cudamapper

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -378,23 +378,7 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps,
 
     // <<<<<<<<<<<<
     // parallel update the overlaps to include the corresponding read names [parallel on host]
-
-#pragma omp parallel for
-    for (size_t i = 0; i < fused_overlaps.size(); i++)
-    {
-        auto& o                      = fused_overlaps[i];
-        std::string query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
-        std::string target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
-
-        o.query_read_name_ = new char[query_read_name.length()];
-        strcpy(o.query_read_name_, query_read_name.c_str());
-
-        o.target_read_name_ = new char[target_read_name.length()];
-        strcpy(o.target_read_name_, target_read_name.c_str());
-
-        o.query_length_  = index_query.read_id_to_read_length(o.query_read_id_);
-        o.target_length_ = index_target.read_id_to_read_length(o.target_read_id_);
-    }
+    Overlapper::update_read_names(fused_overlaps, index_query, index_target);
 }
 
 } // namespace cudamapper

--- a/cudamapper/src/overlapper_triggered.cu
+++ b/cudamapper/src/overlapper_triggered.cu
@@ -196,7 +196,7 @@ OverlapperTriggered::~OverlapperTriggered()
     CGA_CU_CHECK_ERR(cudaStreamDestroy(stream));
 }
 
-void OverlapperTriggered::get_overlaps(std::vector<Overlap> &fused_overlaps, device_buffer <Anchor> &d_anchors)
+void OverlapperTriggered::get_overlaps(std::vector<Overlap>& fused_overlaps, device_buffer<Anchor>& d_anchors)
 {
     CGA_NVTX_RANGE(profiler, "OverlapperTriggered::get_overlaps");
     const auto tail_length_for_chain = 3;
@@ -372,7 +372,6 @@ void OverlapperTriggered::get_overlaps(std::vector<Overlap> &fused_overlaps, dev
     fused_overlaps.resize(n_fused_overlap);
     cudautils::device_copy_n(d_fused_overlaps.data(), n_fused_overlap, fused_overlaps.data(), stream);
     CGA_CU_CHECK_ERR(cudaStreamSynchronize(stream));
-
 }
 
 } // namespace cudamapper

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -33,12 +33,10 @@ public:
     /// Uses a dynamic programming approach where an overlap is "triggered" when a run of
     /// Anchors (e.g 3) with a score above a threshold is encountered and untriggerred
     /// when a single anchor with a threshold below the value is encountered.
-    /// \param overlaps Output vector into which generated overlaps will be placed
-    /// \param anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
-    /// \param index_query
-    /// \param index_target
+    /// \param fused_overlaps Output vector into which generated overlaps will be placed
+    /// \param d_anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
     /// \return vector of Overlap objects
-    void get_overlaps(std::vector<Overlap>& overlaps, device_buffer<Anchor>& anchors, const Index& index_query, const Index& index_target) override;
+    void get_overlaps(std::vector<Overlap> &fused_overlaps, device_buffer <Anchor> &d_anchors) override;
 
     explicit OverlapperTriggered(std::shared_ptr<DeviceAllocator>);
     ~OverlapperTriggered();

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -36,7 +36,7 @@ public:
     /// \param fused_overlaps Output vector into which generated overlaps will be placed
     /// \param d_anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
     /// \return vector of Overlap objects
-    void get_overlaps(std::vector<Overlap> &fused_overlaps, device_buffer <Anchor> &d_anchors) override;
+    void get_overlaps(std::vector<Overlap>& fused_overlaps, device_buffer<Anchor>& d_anchors) override;
 
     explicit OverlapperTriggered(std::shared_ptr<DeviceAllocator>);
     ~OverlapperTriggered();

--- a/cudamapper/src/overlapper_triggered.hpp
+++ b/cudamapper/src/overlapper_triggered.hpp
@@ -25,6 +25,8 @@ namespace cudamapper
 /// Uses a dynamic programming approach where an overlap is "triggered" when a run of
 /// Anchors (e.g 3) with a score above a threshold is encountered and untriggerred
 /// when a single anchor with a threshold below the value is encountered.
+/// query_read_name_ and target_read_name_ in output overlaps are not initialized and
+/// will be updated after Overlapper::update_read_names() call
 class OverlapperTriggered : public Overlapper
 {
 
@@ -33,7 +35,7 @@ public:
     /// Uses a dynamic programming approach where an overlap is "triggered" when a run of
     /// Anchors (e.g 3) with a score above a threshold is encountered and untriggerred
     /// when a single anchor with a threshold below the value is encountered.
-    /// \param fused_overlaps Output vector into which generated overlaps will be placed
+    /// \param fused_overlaps Output vector into which generated overlaps will be placed, query_read_name_ and target_read_name_ for each vector entry remains null. They will be updated after Overlapper::update_read_names() call
     /// \param d_anchors vector of anchors sorted by query_read_id -> target_read_id -> query_position_in_read -> target_position_in_read (meaning sorted by query_read_id, then within a group of anchors with the same value of query_read_id sorted by target_read_id and so on)
     /// \return vector of Overlap objects
     void get_overlaps(std::vector<Overlap>& fused_overlaps, device_buffer<Anchor>& d_anchors) override;

--- a/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
+++ b/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
@@ -254,6 +254,10 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
     ASSERT_EQ(overlaps[0].query_end_position_in_read_, 400u);
     ASSERT_EQ(overlaps[0].target_start_position_in_read_, 1000u);
     ASSERT_EQ(overlaps[0].target_end_position_in_read_, 1300u);
+
+    overlapper.update_read_names(overlaps, test_index, test_index);
+    ASSERT_EQ(strcmp(overlaps[0].query_read_name_, testv[1].c_str()), 0u);
+    ASSERT_EQ(strcmp(overlaps[0].target_read_name_, testv[2].c_str()), 0u);
 }
 
 TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
@@ -434,6 +438,10 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
     ASSERT_EQ(overlaps[0].query_end_position_in_read_, 300u);
     ASSERT_EQ(overlaps[0].target_start_position_in_read_, 1000u);
     ASSERT_EQ(overlaps[0].target_end_position_in_read_, 1200u);
+
+    overlapper.update_read_names(overlaps, test_index, test_index);
+    ASSERT_EQ(strcmp(overlaps[0].query_read_name_, testv[1].c_str()), 0u);
+    ASSERT_EQ(strcmp(overlaps[0].target_read_name_, testv[2].c_str()), 0u);
 }
 
 TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)

--- a/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
+++ b/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
@@ -188,7 +188,7 @@ TEST(TestCudamapperOverlapperTriggerred, OneAchorNoOverlaps)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
@@ -246,7 +246,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsOneOverlap)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_EQ(overlaps[0].query_read_id_, 1u);
     ASSERT_EQ(overlaps[0].target_read_id_, 2u);
@@ -310,7 +310,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsNoOverlap)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
@@ -368,7 +368,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourColinearAnchorsOneOverlap)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 0u);
 }
 
@@ -426,7 +426,7 @@ TEST(TestCudamapperOverlapperTriggerred, FourAnchorsLastNotInOverlap)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_EQ(overlaps[0].query_read_id_, 1u);
     ASSERT_EQ(overlaps[0].target_read_id_, 2u);
@@ -490,7 +490,7 @@ TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)
     cudautils::device_copy_n(anchors.data(), anchors.size(), anchors_d.data()); //H2D
 
     std::vector<Overlap> overlaps;
-    overlapper.get_overlaps(overlaps, anchors_d, test_index, test_index);
+    overlapper.get_overlaps(overlaps, anchors_d);
     ASSERT_EQ(overlaps.size(), 1u);
     ASSERT_GT(overlaps[0].target_end_position_in_read_, overlaps[0].target_start_position_in_read_);
     ASSERT_EQ(overlaps[0].relative_strand, RelativeStrand::Reverse);

--- a/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
+++ b/cudamapper/tests/Test_CudamapperOverlapperTriggered.cu
@@ -503,6 +503,10 @@ TEST(TestCudamapperOverlapperTriggerred, ReverseStrand)
     ASSERT_GT(overlaps[0].target_end_position_in_read_, overlaps[0].target_start_position_in_read_);
     ASSERT_EQ(overlaps[0].relative_strand, RelativeStrand::Reverse);
     ASSERT_EQ(char(overlaps[0].relative_strand), '-');
+
+    overlapper.update_read_names(overlaps, test_index, test_index);
+    ASSERT_EQ(strcmp(overlaps[0].query_read_name_, testv[1].c_str()), 0u);
+    ASSERT_EQ(strcmp(overlaps[0].target_read_name_, testv[2].c_str()), 0u);
 }
 
 } // namespace cudamapper


### PR DESCRIPTION
- detached thread to execute filter_and_print_overlaps is launched more efficiently, as overlaps_to_add vector is passed to std::thread as a shared pointer.

- updating read names for overlap vector is moved outside of get_overlaps and now is performed on detached thread.

- filter_overlaps which takes place on CPU is slightly modified to work with overlap read_ids rather than read_names. This allows to move the omp for loop used for updating read names work on only filtered set of overlaps.
