### PR TITLE
Benchmark mode

### DIFF
--- a/cudamapper/include/claragenomics/cudamapper/types.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/types.hpp
@@ -112,6 +112,26 @@ typedef struct Overlap
 
 } Overlap;
 
+/// Data structure for storing benchmark data
+///
+/// contains vectors keep record of time and memory per benchmark iterations
+/// a benchmark iteration refers to processing one batch of query indices
+struct BenchMarkData
+{
+    /// time (msecs) spent to complete indexer for each benchmark iteration
+    std::vector<double> indexer_time;
+    /// time (msecs) spent to complete matcher for each benchmark iteration
+    std::vector<double> matcher_time;
+    /// time (msecs) spent to complete overlapper for each benchmark iteration
+    std::vector<double> overlapper_time;
+    /// total time (msecs) spent to complete each benchmark iteration
+    std::vector<double> total_time;
+    /// keep track of max device memory (GB) per benchmark iteration
+    std::vector<double> device_mem;
+    /// keep track of max host memory per (GB) benchmark iteration
+    std::vector<double> host_mem;
+};
+
 } // namespace cudamapper
 
 } // namespace claragenomics

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -208,7 +208,7 @@ int main(int argc, char* argv[])
     std::atomic<int> num_overlap_chunks_to_print(0);
 
     // benchmark data per device
-    std::vector<claragenomics::cudamapper::BenchMarkData> benchmark_log(num_devices);
+    std::vector<claragenomics::cudamapper::BenchmarkData> benchmark_log(num_devices);
     // flag indicating benchmark mode is enabled
     const bool benchmark_mode = benchmark_iterations > 0;
 
@@ -378,7 +378,7 @@ int main(int argc, char* argv[])
             evict_index(query_start_index, query_end_index, device_id, num_devices);
         }
 
-        benchmark_log[device_id].update_iteration_data(benchmark_mode);
+        benchmark_log[device_id].update_iteration_data(benchmark_mode, query_end_index - query_start_index);
     };
 
     // The application (File parsing, index generation, overlap generation etc) is all launched from here.
@@ -404,7 +404,7 @@ int main(int argc, char* argv[])
 
                     // if benchmark-mode is activated by entering a positive integer for -b,
                     // limit iterations to benchmark_iterations
-                    if (benchmark_iterations > 0 && range_idx > benchmark_iterations)
+                    if (benchmark_iterations > 0 && (range_idx + 1) > benchmark_iterations)
                     {
                         break;
                     }

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -211,6 +211,14 @@ int main(int argc, char* argv[])
     std::vector<claragenomics::cudamapper::BenchmarkData> benchmark_log(num_devices);
     // flag indicating benchmark mode is enabled
     const bool benchmark_mode = benchmark_iterations > 0;
+    if (benchmark_mode)
+    {
+        for (auto& bg : benchmark_log)
+        {
+            bg.set_benchmark_args(k, w, num_devices, max_index_cache_size_on_device, max_index_cache_size_on_host,
+                                  max_cached_memory, index_size, target_index_size, filtering_parameter);
+        }
+    }
 
     auto get_index = [&device_index_cache, &host_index_cache, max_index_cache_size_on_device,
                       max_index_cache_size_on_host, &benchmark_log](claragenomics::DefaultDeviceAllocator allocator,


### PR DESCRIPTION
This PR adds a basic benchmark mode that allows running cudamapper for a limited number of iterations. This mode can be activated by -b (some positive integer), e.g.
`./cudamapper data/chrx.fasta data/chrx.fasta -b 1`

At each iteration, the time spent on indexer, matcher and overlapper is recorded. At the end a summary like this is displayed to the user:

benchmark summary:
\=========================================================
iteration 0
indexer (sec)     27.13`       .......................................`
matcher (sec)     1.40 `     ...`
overlapper (sec)  0.28 `       .`
host mem. (GB)    18.97
device mem. (GB)  1.68
performance (s/k) 24.8
\______________________________________________________________________________________________
number of benchmark iterations : 2
input args : -k 15 -w 15 -d 1 -c 0 -C 100 -m 1 -i 30 -t 30 -F 0.0
maximum used device memory (GB): 1.74
maximum used host memory (GB)  : 19.08
\=========================================================
