### PR TITLE
fixed memory leak

### DIFF
--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -332,7 +332,7 @@ int main(int argc, char* argv[])
                     claragenomics::cudamapper::Overlapper::print_paf(filtered_overlaps);
 
                     //clear data
-                    for (auto o : *overlaps)
+                    for (auto o : filtered_overlaps)
                     {
                         o.clear();
                     }


### PR DESCRIPTION
updating read names was applied to filtered set of overlaps, but the call for freeing memory was not changed accordingly. fixed!