### PR TITLE
[cudamapper] Call cudaSetDevice() for writer thread

### DIFF
--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -215,7 +215,7 @@ public:
     pointer allocate(std::size_t n, cudaStream_t stream = 0)
     {
         void* ptr = 0;
-        CGA_CU_ABORT_ON_ERR(cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream));
+        CGA_CU_CHECK_ERR(cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream));
         return static_cast<pointer>(ptr);
     }
 

--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -215,7 +215,7 @@ public:
     pointer allocate(std::size_t n, cudaStream_t stream = 0)
     {
         void* ptr = 0;
-        cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream);
+        CGA_CU_CHECK_ERR(cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream));
         return static_cast<pointer>(ptr);
     }
 
@@ -226,7 +226,7 @@ public:
     void deallocate(pointer p, std::size_t n, cudaStream_t stream = 0)
     {
         // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
-        cub_allocator_->DeviceFree(p);
+        CGA_CU_CHECK_ERR(cub_allocator_->DeviceFree(p));
     }
 
     /// @brief returns a shared pointer to internally used cub::CachingDeviceAllocator

--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -215,7 +215,7 @@ public:
     pointer allocate(std::size_t n, cudaStream_t stream = 0)
     {
         void* ptr = 0;
-        CGA_CU_CHECK_ERR(cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream));
+        CGA_CU_ABORT_ON_ERR(cub_allocator_->DeviceAllocate(&ptr, n * sizeof(T), stream));
         return static_cast<pointer>(ptr);
     }
 
@@ -225,8 +225,7 @@ public:
     /// @param stream CUDA stream to be associated with this method.
     void deallocate(pointer p, std::size_t n, cudaStream_t stream = 0)
     {
-        // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
-        CGA_CU_CHECK_ERR(cub_allocator_->DeviceFree(p));
+        CGA_CU_ABORT_ON_ERR(cub_allocator_->DeviceFree(p));
     }
 
     /// @brief returns a shared pointer to internally used cub::CachingDeviceAllocator

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -37,7 +37,7 @@
 
 /// \ingroup cudautils
 /// \def CGA_CU_ABORT_ON_ERR
-/// \brief Log on CUDA error in enclosed expression
+/// \brief Log on CUDA error in enclosed expression and termine in release mode, fail assertion in debug mode
 #define CGA_CU_ABORT_ON_ERR(ans)                                         \
     {                                                                    \
         claragenomics::cudautils::gpu_assert((ans), __FILE__, __LINE__); \

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -32,14 +32,13 @@
     {                                                                    \
         claragenomics::cudautils::gpu_assert((ans), __FILE__, __LINE__); \
     }
-/// \}
 // ^^^^ CGA_CU_CHECK_ERR currently has the same implementation as CGA_CU_ABORT_ON_ERR.
 //      The idea is that in the future CGA_CU_CHECK_ERR could have a "softer" error reporting (= not calling std::abort)
 
 /// \ingroup cudautils
 /// \def CGA_CU_ABORT_ON_ERR
 /// \brief Log on CUDA error in enclosed expression
-#define CGA_CU_ABORT_ON_ERR(ans)                                            \
+#define CGA_CU_ABORT_ON_ERR(ans)                                         \
     {                                                                    \
         claragenomics::cudautils::gpu_assert((ans), __FILE__, __LINE__); \
     }

--- a/common/utils/include/claragenomics/utils/cudautils.hpp
+++ b/common/utils/include/claragenomics/utils/cudautils.hpp
@@ -32,6 +32,17 @@
     {                                                                    \
         claragenomics::cudautils::gpu_assert((ans), __FILE__, __LINE__); \
     }
+/// \}
+// ^^^^ CGA_CU_CHECK_ERR currently has the same implementation as CGA_CU_ABORT_ON_ERR.
+//      The idea is that in the future CGA_CU_CHECK_ERR could have a "softer" error reporting (= not calling std::abort)
+
+/// \ingroup cudautils
+/// \def CGA_CU_ABORT_ON_ERR
+/// \brief Log on CUDA error in enclosed expression
+#define CGA_CU_ABORT_ON_ERR(ans)                                            \
+    {                                                                    \
+        claragenomics::cudautils::gpu_assert((ans), __FILE__, __LINE__); \
+    }
 
 /// \}
 

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -278,8 +278,6 @@ int main(int argc, char* argv[])
 #endif
 
     auto compute_overlaps = [&](const QueryTargetsRange& query_target_range, const int device_id) {
-        cudaSetDevice(device_id);
-
         auto query_start_index = query_target_range.query_range.first;
         auto query_end_index   = query_target_range.query_range.second;
 
@@ -368,6 +366,7 @@ int main(int argc, char* argv[])
         //Worker thread consumes query-target ranges off a queue
         workers.push_back(std::thread(
             [&, device_id]() {
+                cudaSetDevice(device_id);
                 while (ranges_idx < get_size<int>(query_target_ranges))
                 {
                     int range_idx = ranges_idx.fetch_add(1);


### PR DESCRIPTION
When a new host thread is created it does not inherit `current device` from its parent, it simply gets assigned `device 0`. This can cause problems because two threads use different device/contexts.

This PR sets device in writer threads to same device as their launching worker thread.

This PR also introduces `CGA_CU_ABORT_ON_ERR`

Closes #306