### PR TITLE
[common] minor fixes

### DIFF
--- a/common/utils/include/claragenomics/utils/allocator.hpp
+++ b/common/utils/include/claragenomics/utils/allocator.hpp
@@ -13,6 +13,7 @@
 #include <memory>
 #include <type_traits>
 
+#include <cuda_runtime_api.h>
 #include <cub/util_allocator.cuh>
 #include <claragenomics/utils/device_preallocated_allocator.cuh>
 
@@ -46,6 +47,7 @@ public:
     template <typename U>
     CudaMallocAllocator(const CudaMallocAllocator<U>& rhs)
     {
+        static_cast<void>(rhs);
     }
 
     /// @brief copy assignment operator
@@ -102,6 +104,7 @@ public:
     /// @return pointer to allocated array
     pointer allocate(std::size_t n, cudaStream_t stream = 0)
     {
+        static_cast<void>(stream);
         void* ptr = 0;
         CGA_CU_CHECK_ERR(cudaMalloc(&ptr, n * sizeof(T)));
         return static_cast<pointer>(ptr);
@@ -113,6 +116,8 @@ public:
     /// @param stream CUDA stream to be associated with this method.
     void deallocate(pointer p, std::size_t n, cudaStream_t stream = 0)
     {
+        static_cast<void>(n);
+        static_cast<void>(stream);
         CGA_CU_ABORT_ON_ERR(cudaFree(p));
     }
 };
@@ -219,6 +224,8 @@ public:
     /// @param stream CUDA stream to be associated with this method.
     void deallocate(pointer p, std::size_t n, cudaStream_t stream = 0)
     {
+        static_cast<void>(n);
+        static_cast<void>(stream);
         // deallocate should not throw execeptions which is why CGA_CU_CHECK_ERR is not used.
         CGA_CU_ABORT_ON_ERR(memory_resource_->DeviceFree(p));
     }

--- a/common/utils/include/claragenomics/utils/buffer.hpp
+++ b/common/utils/include/claragenomics/utils/buffer.hpp
@@ -70,7 +70,7 @@ public:
     /// @param allocator The allocator to use by this buffer.
     /// @param stream The CUDA stream to be associated with this allocation. Default is stream 0.
     /// @tparam AllocatorIn Type of input allocator. If AllocatorIn::value_type is different than T AllocatorIn will be converted to Allocator<T> if possible, compilation will fail otherwise
-    template <typename AllocatorIn>
+    template <typename AllocatorIn, std::enable_if_t<std::is_class<AllocatorIn>::value, int> = 0> // for calls like buffer(5, stream) the other constructor should be used -> only enable if AllocatorIn is a class.
     explicit buffer(AllocatorIn allocator, cudaStream_t stream = 0)
         : buffer(0, allocator, stream)
     {

--- a/common/utils/include/claragenomics/utils/device_preallocated_allocator.cuh
+++ b/common/utils/include/claragenomics/utils/device_preallocated_allocator.cuh
@@ -58,7 +58,7 @@ public:
         , buffer_ptr_(create_buffer(buffer_size))
     {
         assert(buffer_size > 0);
-        free_blocks_.push_back({0, buffer_size});
+        free_blocks_.push_back({0, buffer_size, 0});
     }
 
     DevicePreallocatedAllocator(const DevicePreallocatedAllocator&) = delete;
@@ -116,11 +116,11 @@ private:
     /// @brief allocates the underlying buffer
     /// @param buffer_size
     /// @return allocated shared_ptr
-    std::unique_ptr<char, void (*)(char*)> create_buffer(size_t buffer_size)
+    static std::unique_ptr<char, void (*)(char*)> create_buffer(size_t buffer_size)
     {
         // shared_ptr creation packed in a function so it can be used in constructor's initilaization list
         void* ptr = nullptr;
-        CGA_CU_CHECK_ERR(cudaMalloc(&ptr, buffer_size_));
+        CGA_CU_CHECK_ERR(cudaMalloc(&ptr, buffer_size));
         auto ret_val = std::unique_ptr<char, void (*)(char*)>(static_cast<char*>(ptr),
                                                               [](char* ptr) {
                                                                   CGA_CU_ABORT_ON_ERR(cudaFree(ptr));


### PR DESCRIPTION
* [common] allocator added missing include + fixed unused variable warnings
* [common] buffer: avoid buffer(Allocator, cudaStream = 0) constructor for buffer(n) calls.
* [common] preallocated allocator: minor changes:
  * initialize stream member of first memory block
  * make create_buffer(buffer_size) use argument instead of buffer_size_ member
