### PR TITLE
[cudamapper] Renamed HostCache to IndexHostCopy

### DIFF
--- a/cudamapper/CMakeLists.txt
+++ b/cudamapper/CMakeLists.txt
@@ -31,7 +31,7 @@ target_compile_options(minimizer PRIVATE -Werror)
 cuda_add_library(index_gpu
         src/index.cu
         src/index_gpu.cu
-        src/host_cache.cu
+        src/index_host_copy.cu
         src/minimizer.cu)
 target_include_directories(index_gpu PUBLIC include ${CUB_DIR})
 target_link_libraries(index_gpu logging minimizer pthread utils cgaio)

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -134,6 +134,9 @@ public:
     virtual std::unique_ptr<Index> copy_index_to_device(DefaultDeviceAllocator allocator,
                                                         const cudaStream_t cuda_stream = 0) = 0;
 
+    /// \brief virtual destructor
+    virtual ~IndexHostCopyBase() = delete;
+
     /// \brief returns an array of representations of sketch elements (stored on host)
     /// \return an array of representations of sketch elements
     virtual const std::vector<representation_t>& representations() const = 0;

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -121,10 +121,10 @@ public:
                  const cudaStream_t cuda_stream   = 0);
 };
 
-/// IndexHostCopy - Creates and maintains a copy of computed IndexGPU elements on the host, then allows to retrieve target
+/// IndexHostCopyBase - Creates and maintains a copy of computed IndexGPU elements on the host, then allows to retrieve target
 /// indices from host instead of recomputing them again
 ///
-class IndexHostCopy
+class IndexHostCopyBase
 {
 public:
     /// \brief copy cached index vectors from the host and create an object of Index on GPU
@@ -193,12 +193,12 @@ public:
     /// \param kmer_size - number of basepairs in a k-mer
     /// \param window_size the number of adjacent k-mers in a window, adjacent = shifted by one basepair
     /// \param cuda_stream D2H copy is done on this stream
-    /// \return - an instance of IndexHostCopy
-    static std::unique_ptr<IndexHostCopy> create_cache(const Index& index,
-                                                       const read_id_t first_read_id,
-                                                       const std::uint64_t kmer_size,
-                                                       const std::uint64_t window_size,
-                                                       const cudaStream_t cuda_stream = 0);
+    /// \return - an instance of IndexHostCopyBase
+    static std::unique_ptr<IndexHostCopyBase> create_cache(const Index& index,
+                                                           const read_id_t first_read_id,
+                                                           const std::uint64_t kmer_size,
+                                                           const std::uint64_t window_size,
+                                                           const cudaStream_t cuda_stream = 0);
 };
 
 } // namespace cudamapper

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -135,7 +135,7 @@ public:
                                                         const cudaStream_t cuda_stream = 0) = 0;
 
     /// \brief virtual destructor
-    virtual ~IndexHostCopyBase() = delete;
+    virtual ~IndexHostCopyBase() = default;
 
     /// \brief returns an array of representations of sketch elements (stored on host)
     /// \return an array of representations of sketch elements

--- a/cudamapper/src/index.cu
+++ b/cudamapper/src/index.cu
@@ -40,18 +40,18 @@ std::unique_ptr<Index> Index::create_index(DefaultDeviceAllocator allocator,
                                                  cuda_stream);
 }
 
-std::unique_ptr<IndexHostCopy> IndexHostCopy::create_cache(const Index& index,
-                                                           const read_id_t first_read_id,
-                                                           const std::uint64_t kmer_size,
-                                                           const std::uint64_t window_size,
-                                                           const cudaStream_t cuda_stream)
+std::unique_ptr<IndexHostCopyBase> IndexHostCopyBase::create_cache(const Index& index,
+                                                                   const read_id_t first_read_id,
+                                                                   const std::uint64_t kmer_size,
+                                                                   const std::uint64_t window_size,
+                                                                   const cudaStream_t cuda_stream)
 {
     CGA_NVTX_RANGE(profiler, "cache_D2H");
-    return std::make_unique<HostCache>(index,
-                                       first_read_id,
-                                       kmer_size,
-                                       window_size,
-                                       cuda_stream);
+    return std::make_unique<IndexHostCopy>(index,
+                                           first_read_id,
+                                           kmer_size,
+                                           window_size,
+                                           cuda_stream);
 }
 
 } // namespace cudamapper

--- a/cudamapper/src/index_host_copy.cu
+++ b/cudamapper/src/index_host_copy.cu
@@ -9,7 +9,7 @@
 */
 
 #include <thrust/copy.h>
-#include "host_cache.cuh"
+#include "index_host_copy.cuh"
 #include "index_gpu.cuh"
 #include "minimizer.hpp"
 
@@ -18,11 +18,11 @@ namespace claragenomics
 namespace cudamapper
 {
 
-HostCache::HostCache(const Index& index,
-                     const read_id_t first_read_id,
-                     const std::uint64_t kmer_size,
-                     const std::uint64_t window_size,
-                     const cudaStream_t cuda_stream)
+IndexHostCopy::IndexHostCopy(const Index& index,
+                             const read_id_t first_read_id,
+                             const std::uint64_t kmer_size,
+                             const std::uint64_t window_size,
+                             const cudaStream_t cuda_stream)
     : first_read_id_(first_read_id)
     , kmer_size_(kmer_size)
     , window_size_(window_size)
@@ -76,75 +76,75 @@ HostCache::HostCache(const Index& index,
     CGA_CU_CHECK_ERR(cudaStreamSynchronize(cuda_stream));
 }
 
-std::unique_ptr<Index> HostCache::copy_index_to_device(DefaultDeviceAllocator allocator,
-                                                       const cudaStream_t cuda_stream)
+std::unique_ptr<Index> IndexHostCopy::copy_index_to_device(DefaultDeviceAllocator allocator,
+                                                           const cudaStream_t cuda_stream)
 {
     return std::make_unique<IndexGPU<Minimizer>>(allocator,
                                                  *this,
                                                  cuda_stream);
 }
 
-const std::vector<representation_t>& HostCache::representations() const
+const std::vector<representation_t>& IndexHostCopy::representations() const
 {
     return representations_;
 }
 
-const std::vector<read_id_t>& HostCache::read_ids() const
+const std::vector<read_id_t>& IndexHostCopy::read_ids() const
 {
     return read_ids_;
 }
 
-const std::vector<position_in_read_t>& HostCache::positions_in_reads() const
+const std::vector<position_in_read_t>& IndexHostCopy::positions_in_reads() const
 {
     return positions_in_reads_;
 }
 
-const std::vector<SketchElement::DirectionOfRepresentation>& HostCache::directions_of_reads() const
+const std::vector<SketchElement::DirectionOfRepresentation>& IndexHostCopy::directions_of_reads() const
 {
     return directions_of_reads_;
 }
 
-const std::vector<representation_t>& HostCache::unique_representations() const
+const std::vector<representation_t>& IndexHostCopy::unique_representations() const
 {
     return unique_representations_;
 }
 
-const std::vector<std::uint32_t>& HostCache::first_occurrence_of_representations() const
+const std::vector<std::uint32_t>& IndexHostCopy::first_occurrence_of_representations() const
 {
     return first_occurrence_of_representations_;
 }
 
-const std::vector<std::string>& HostCache::read_id_to_read_names() const
+const std::vector<std::string>& IndexHostCopy::read_id_to_read_names() const
 {
     return read_id_to_read_name_;
 }
 
-const std::vector<std::uint32_t>& HostCache::read_id_to_read_lengths() const
+const std::vector<std::uint32_t>& IndexHostCopy::read_id_to_read_lengths() const
 {
     return read_id_to_read_length_;
 }
 
-read_id_t HostCache::number_of_reads() const
+read_id_t IndexHostCopy::number_of_reads() const
 {
     return number_of_reads_;
 }
 
-position_in_read_t HostCache::number_of_basepairs_in_longest_read() const
+position_in_read_t IndexHostCopy::number_of_basepairs_in_longest_read() const
 {
     return number_of_basepairs_in_longest_read_;
 }
 
-read_id_t HostCache::first_read_id() const
+read_id_t IndexHostCopy::first_read_id() const
 {
     return first_read_id_;
 }
 
-std::uint64_t HostCache::kmer_size() const
+std::uint64_t IndexHostCopy::kmer_size() const
 {
     return kmer_size_;
 }
 
-std::uint64_t HostCache::window_size() const
+std::uint64_t IndexHostCopy::window_size() const
 {
     return window_size_;
 }

--- a/cudamapper/src/index_host_copy.cuh
+++ b/cudamapper/src/index_host_copy.cuh
@@ -16,10 +16,10 @@ namespace claragenomics
 {
 namespace cudamapper
 {
-/// HostCache - Creates and maintains a copy of computed IndexGPU elements on the host
+/// IndexHostCopy - Creates and maintains a copy of computed IndexGPU elements on the host
 ///
 ///
-class HostCache : public IndexHostCopy
+class IndexHostCopy : public IndexHostCopyBase
 {
 public:
     /// \brief Constructor
@@ -30,11 +30,11 @@ public:
     /// \param window_size the number of adjacent k-mers in a window, adjacent = shifted by one basepair
     /// \param cuda_stream D2H copy is done on this stream
     /// \return - pointer to claragenomics::cudamapper::IndexCache
-    explicit HostCache(const Index& index,
-                       const read_id_t first_read_id,
-                       const std::uint64_t kmer_size,
-                       const std::uint64_t window_size,
-                       const cudaStream_t cuda_stream);
+    explicit IndexHostCopy(const Index& index,
+                           const read_id_t first_read_id,
+                           const std::uint64_t kmer_size,
+                           const std::uint64_t window_size,
+                           const cudaStream_t cuda_stream);
 
     /// \brief copy cached index vectors from the host and create an object of Index on GPU
     /// \param allocator pointer to asynchronous device allocator

--- a/cudamapper/src/index_host_copy.cuh
+++ b/cudamapper/src/index_host_copy.cuh
@@ -30,11 +30,11 @@ public:
     /// \param window_size the number of adjacent k-mers in a window, adjacent = shifted by one basepair
     /// \param cuda_stream D2H copy is done on this stream
     /// \return - pointer to claragenomics::cudamapper::IndexCache
-    explicit IndexHostCopy(const Index& index,
-                           const read_id_t first_read_id,
-                           const std::uint64_t kmer_size,
-                           const std::uint64_t window_size,
-                           const cudaStream_t cuda_stream);
+    IndexHostCopy(const Index& index,
+                  const read_id_t first_read_id,
+                  const std::uint64_t kmer_size,
+                  const std::uint64_t window_size,
+                  const cudaStream_t cuda_stream);
 
     /// \brief copy cached index vectors from the host and create an object of Index on GPU
     /// \param allocator pointer to asynchronous device allocator

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -341,7 +341,7 @@ int main(int argc, char* argv[])
     }
 
     // This is host cache, if it has the index it will copy it to device, if not it will generate on device and add it to host cache
-    std::map<std::pair<uint64_t, uint64_t>, std::shared_ptr<claragenomics::cudamapper::IndexHostCopy>> host_index_cache;
+    std::map<std::pair<uint64_t, uint64_t>, std::shared_ptr<claragenomics::cudamapper::IndexHostCopyBase>> host_index_cache;
 
     // This is a per-device cache, if it has the index it will return it, if not it will generate it, store and return it.
     std::vector<std::map<std::pair<uint64_t, uint64_t>, std::shared_ptr<claragenomics::cudamapper::Index>>> device_index_cache(parameters.num_devices);
@@ -399,11 +399,11 @@ int main(int argc, char* argv[])
             else if (get_size<int32_t>(host_index_cache) < parameters.max_index_cache_size_on_host && allow_cache_index && device_id == 0)
             {
                 // if not cached on device, update host cache; only done on device 0 to avoid any race conditions in updating the host cache
-                host_index_cache[key] = claragenomics::cudamapper::IndexHostCopy::create_cache(*index,
-                                                                                               start_index,
-                                                                                               k,
-                                                                                               w,
-                                                                                               cuda_stream);
+                host_index_cache[key] = claragenomics::cudamapper::IndexHostCopyBase::create_cache(*index,
+                                                                                                   start_index,
+                                                                                                   k,
+                                                                                                   w,
+                                                                                                   cuda_stream);
             }
         }
         return index;


### PR DESCRIPTION
`HostCache` class name is a bit misleading. `IndexHostCopy` reflects the purpose better as the object is an actual copy of an index in host memory.
I'm not completely happy with reaming base `IndexHostCopy` into `IndexHostCopyBase`, but I do feel that `IndexHostCopy` is something we should expose externally.

This PR is part of preparations for the main PR for issue #318