### PR TITLE
[common] clear cuda error in cached allocator

### DIFF
--- a/common/base/include/claragenomics/utils/allocator.hpp
+++ b/common/base/include/claragenomics/utils/allocator.hpp
@@ -243,6 +243,8 @@ public:
         cudaError_t err = memory_resource_->DeviceAllocate(&ptr, n * sizeof(T), stream);
         if (err == cudaErrorMemoryAllocation)
         {
+            // Run cudaGetLastError() to clear the CUDA error before throwing the exception.
+            cudaGetLastError();
             throw device_memory_allocation_exception();
         }
         CGA_CU_CHECK_ERR(err);


### PR DESCRIPTION
This was causing an issue with cudaaligner benchmark where a subsequent run was failing because of the uncleared cuda error