### PR TITLE
Close the loop on BatchSize in CUDAPoa libraries...

### DIFF
--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -65,7 +65,7 @@ cdef class CudaPoaBatch:
 
     def __cinit__(
             self,
-            max_seq_per_poa,
+            max_sequences_per_poa,
             max_gpu_mem,
             output_mask=cudapoa.consensus,
             device_id=0,
@@ -74,7 +74,7 @@ cdef class CudaPoaBatch:
             mismatch_score=-6,
             match_score=8,
             cuda_banded_alignment=False,
-            max_seq_size=1024,            
+            max_sequence_size=1024,
             max_concensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,
@@ -84,15 +84,19 @@ cdef class CudaPoaBatch:
         partial order alignment across all windows in the batch.
 
         Args:
-            device_id : ID of GPU device to use
-            stream : CudaStream to use for GPU execution
+            max_sequences_per_poa : Maximum number of sequences per POA
             max_gpu_mem : Maximum GPU memory to use for this batch
             output_mask : Types of outputs to generate (consensus, msa)
-            batch_size : Structure encapsulating upper limits for POA batches
+            device_id : ID of GPU device to use
+            stream : CudaStream to use for GPU execution
             gap_score : Penalty for gaps
             mismatch_score : Penalty for mismatches
             match_score : Reward for match
             cuda_banded_alignment : Run POA using banded alignment
+            max_sequence_size : Maximum number of elements in a sequence
+            max_concensus_size : Maximum size of final consensus
+            max_nodes_per_window : Maximum number of nodes in a graph, 1 graph per window
+            max_nodes_per_window_banded : Maximum number of nodes in a graph, 1 graph per window in banded mode
         """
         cdef size_t st
         cdef _Stream temp_stream
@@ -106,14 +110,14 @@ cdef class CudaPoaBatch:
 
         # Since cython make_unique doesn't accept python objects, need to
         # store it in a cdef and then pass into the make unique call
-        cdef int32_t mx_seq_sz = max_seq_size
-        cdef int32_t mx_seq_per_poa = max_seq_per_poa
+        cdef int32_t mx_seq_sz = max_sequence_size
+        cdef int32_t mx_seq_per_poa = max_sequences_per_poa
         cdef int32_t mx_concensus_sz = \
-            2 * max_seq_size if max_concensus_size is None else max_concensus_size
+            2 * max_sequence_size if max_concensus_size is None else max_concensus_size
         cdef int32_t mx_nodes_per_w = \
-            3 * max_seq_size if max_nodes_per_window is None else max_nodes_per_window
+            3 * max_sequence_size if max_nodes_per_window is None else max_nodes_per_window
         cdef int32_t mx_nodes_per_w_banded = \
-            4 * max_seq_size if max_nodes_per_window_banded is None else max_nodes_per_window_banded
+            4 * max_sequence_size if max_nodes_per_window_banded is None else max_nodes_per_window_banded
 
         self.batch_size = make_unique[cudapoa.BatchSize](
             mx_seq_sz, mx_concensus_sz, mx_nodes_per_w,
@@ -132,7 +136,7 @@ cdef class CudaPoaBatch:
 
     def __init__(
             self,
-            max_seq_per_poa,
+            max_sequences_per_poa,
             max_gpu_mem,
             output_mask=cudapoa.consensus,
             device_id=0,
@@ -141,7 +145,7 @@ cdef class CudaPoaBatch:
             mismatch_score=-6,
             match_score=8,
             cuda_banded_alignment=False,
-            max_seq_size=1024,            
+            max_sequence_size=1024,
             max_concensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -128,7 +128,7 @@ cdef class CudaPoaBatch:
             temp_stream,
             max_gpu_mem,
             output_mask,
-            deref(self.batch_size.get()),
+            deref(self.batch_size),
             gap_score,
             mismatch_score,
             match_score,

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -68,7 +68,7 @@ cdef class CudaPoaBatch:
             max_sequences_per_poa,
             max_sequence_size,
             max_gpu_mem,
-            output_mask=cudapoa.consensus,
+            output_type="consensus",
             device_id=0,
             stream=None,
             gap_score=-8,
@@ -87,7 +87,7 @@ cdef class CudaPoaBatch:
             max_sequences_per_poa : Maximum number of sequences per POA
             max_sequence_size : Maximum number of elements in a sequence
             max_gpu_mem : Maximum GPU memory to use for this batch
-            output_mask : Types of outputs to generate (consensus, msa)
+            output_type : Types of outputs to generate (consensus, msa)
             device_id : ID of GPU device to use
             stream : CudaStream to use for GPU execution
             gap_score : Penalty for gaps
@@ -107,6 +107,13 @@ cdef class CudaPoaBatch:
         else:
             st = stream.stream
             temp_stream = <_Stream>st
+
+        if (output_type == "consensus"):
+            output_mask = cudapoa.consensus
+        elif (output_type == "msa"):
+            output_mask = cudapoa.msa
+        else:
+            raise RuntimeError("Unknown output_type provided. Must be consensus/msa.")
 
         # Since cython make_unique doesn't accept python objects, need to
         # store it in a cdef and then pass into the make unique call
@@ -139,7 +146,7 @@ cdef class CudaPoaBatch:
             max_sequences_per_poa,
             max_sequence_size,
             max_gpu_mem,
-            output_mask=cudapoa.consensus,
+            output_type="consensus",
             device_id=0,
             stream=None,
             gap_score=-8,

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -109,9 +109,9 @@ cdef class CudaPoaBatch:
         cdef int32_t max_seq_per_poa = batch_size.max_seq_per_poa
 
         self.batch_size = make_unique[cudapoa.BatchSize](
-            max_seq_sz, max_concensus_sz,  max_nodes_per_w,
+            max_seq_sz, max_concensus_sz, max_nodes_per_w,
             max_nodes_per_w_banded, max_seq_per_poa)
-        
+
         cdef int32_t max_seqs = batch_size.max_sequences_per_poa
 
         self.batch = cudapoa.create_batch(

--- a/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
+++ b/pyclaragenomics/claragenomics/bindings/cudapoa.pyx
@@ -66,6 +66,7 @@ cdef class CudaPoaBatch:
     def __cinit__(
             self,
             max_sequences_per_poa,
+            max_sequence_size,
             max_gpu_mem,
             output_mask=cudapoa.consensus,
             device_id=0,
@@ -74,7 +75,6 @@ cdef class CudaPoaBatch:
             mismatch_score=-6,
             match_score=8,
             cuda_banded_alignment=False,
-            max_sequence_size=1024,
             max_concensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,
@@ -85,6 +85,7 @@ cdef class CudaPoaBatch:
 
         Args:
             max_sequences_per_poa : Maximum number of sequences per POA
+            max_sequence_size : Maximum number of elements in a sequence
             max_gpu_mem : Maximum GPU memory to use for this batch
             output_mask : Types of outputs to generate (consensus, msa)
             device_id : ID of GPU device to use
@@ -93,7 +94,6 @@ cdef class CudaPoaBatch:
             mismatch_score : Penalty for mismatches
             match_score : Reward for match
             cuda_banded_alignment : Run POA using banded alignment
-            max_sequence_size : Maximum number of elements in a sequence
             max_concensus_size : Maximum size of final consensus
             max_nodes_per_window : Maximum number of nodes in a graph, 1 graph per window
             max_nodes_per_window_banded : Maximum number of nodes in a graph, 1 graph per window in banded mode
@@ -137,6 +137,7 @@ cdef class CudaPoaBatch:
     def __init__(
             self,
             max_sequences_per_poa,
+            max_sequence_size,
             max_gpu_mem,
             output_mask=cudapoa.consensus,
             device_id=0,
@@ -145,7 +146,6 @@ cdef class CudaPoaBatch:
             mismatch_score=-6,
             match_score=8,
             cuda_banded_alignment=False,
-            max_sequence_size=1024,
             max_concensus_size=None,
             max_nodes_per_window=None,
             max_nodes_per_window_banded=None,

--- a/pyclaragenomics/samples/sample_cudapoa
+++ b/pyclaragenomics/samples/sample_cudapoa
@@ -41,6 +41,7 @@ def run_cudapoa(groups, msa, print_output):
     max_seq_sz = 1024
     batch = cudapoa.CudaPoaBatch(max_sequences_per_poa,
                                  max_seq_sz,
+                                 0.9 * free,
                                  stream=None,
                                  output_mask=msa)
 

--- a/pyclaragenomics/samples/sample_cudapoa
+++ b/pyclaragenomics/samples/sample_cudapoa
@@ -39,10 +39,10 @@ def run_cudapoa(groups, msa, print_output):
     # Create batch
     max_seq_sz = 1024
     max_sequences_per_poa = 100
-    batch_size = cudapoa.BatchSize(max_seq_sz, max_sequences_per_poa)
     batch = cudapoa.CudaPoaBatch(stream=None,
                                  output_mask=msa,
-                                 batch_size=batch_size)
+                                 max_seq_size=max_seq_sz, 
+                                 max_sequences_per_poa=max_sequences_per_poa)
 
     # Add poa groups to batch
     initial_count = 0

--- a/pyclaragenomics/samples/sample_cudapoa
+++ b/pyclaragenomics/samples/sample_cudapoa
@@ -39,11 +39,12 @@ def run_cudapoa(groups, msa, print_output):
     # Create batch
     max_sequences_per_poa = 100
     max_seq_sz = 1024
+    gpu_mem_per_batch = 0.9 * free
     batch = cudapoa.CudaPoaBatch(max_sequences_per_poa,
                                  max_seq_sz,
-                                 0.9 * free,
+                                 gpu_mem_per_batch,
                                  stream=None,
-                                 output_mask=msa)
+                                 output_type=("msa" if msa else "consensus"))
 
     # Add poa groups to batch
     initial_count = 0

--- a/pyclaragenomics/samples/sample_cudapoa
+++ b/pyclaragenomics/samples/sample_cudapoa
@@ -37,12 +37,12 @@ def run_cudapoa(groups, msa, print_output):
     free, total = cuda.cuda_get_mem_info(cuda.cuda_get_device())
 
     # Create batch
+    max_seq_sz = 1024
     max_sequences_per_poa = 100
-    gpu_mem_per_batch = 0.9 * free
-    batch = cudapoa.CudaPoaBatch(max_sequences_per_poa,
-                                 gpu_mem_per_batch,
-                                 stream=None,
-                                 output_type=("msa" if msa else "consensus"))
+    batch_size = cudapoa.BatchSize(max_seq_sz, max_sequences_per_poa)
+    batch = cudapoa.CudaPoaBatch(stream=None,
+                                 output_mask=msa,
+                                 batch_size=batch_size)
 
     # Add poa groups to batch
     initial_count = 0

--- a/pyclaragenomics/samples/sample_cudapoa
+++ b/pyclaragenomics/samples/sample_cudapoa
@@ -37,12 +37,12 @@ def run_cudapoa(groups, msa, print_output):
     free, total = cuda.cuda_get_mem_info(cuda.cuda_get_device())
 
     # Create batch
-    max_seq_sz = 1024
     max_sequences_per_poa = 100
-    batch = cudapoa.CudaPoaBatch(stream=None,
-                                 output_mask=msa,
-                                 max_seq_size=max_seq_sz, 
-                                 max_sequences_per_poa=max_sequences_per_poa)
+    max_seq_sz = 1024
+    batch = cudapoa.CudaPoaBatch(max_sequences_per_poa,
+                                 max_seq_sz,
+                                 stream=None,
+                                 output_mask=msa)
 
     # Add poa groups to batch
     initial_count = 0

--- a/pyclaragenomics/test/test_cudapoa_bindings.py
+++ b/pyclaragenomics/test/test_cudapoa_bindings.py
@@ -20,7 +20,7 @@ import claragenomics.bindings.cuda as cuda
 def test_cudapoa_simple_batch():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
-    batch = CudaPoaBatch(10, 0.9 * free, deivce_id=device)
+    batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device)
     poa_1 = ["ACTGACTG", "ACTTACTG", "ACGGACTG", "ATCGACTG"]
     poa_2 = ["ACTGAC", "ACTTAC", "ACGGAC", "ATCGAC"]
     batch.add_poa_group(poa_1)
@@ -36,7 +36,7 @@ def test_cudapoa_simple_batch():
 def test_cudapoa_reset_batch():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
-    batch = CudaPoaBatch(10, 0.9 * free, device_id=device)
+    batch = CudaPoaBatch(10, 1024, 0.9 * free, device_id=device)
     poa_1 = ["ACTGACTG", "ACTTACTG", "ACGGACTG", "ATCGACTG"]
     batch.add_poa_group(poa_1)
     batch.generate_poa()
@@ -53,7 +53,7 @@ def test_cudapoa_reset_batch():
 def test_cudapoa_graph():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
-    batch = CudaPoaBatch(10, 0.9 * free, device_id=device)
+    batch = CudaPoaBatch(10, 1024, 0.9 * free, device_id=device)
     poa_1 = ["ACTGACTG", "ACTTACTG", "ACTCACTG"]
     batch.add_poa_group(poa_1)
     batch.generate_poa()
@@ -91,7 +91,7 @@ def test_cudapoa_complex_batch():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
     stream = cuda.CudaStream()
-    batch = CudaPoaBatch(1000, 0.9 * free, stream=stream, device_id=device)
+    batch = CudaPoaBatch(1000, 1024, 0.9 * free, stream=stream, device_id=device)
     (add_status, seq_status) = batch.add_poa_group(reads)
     batch.generate_poa()
 

--- a/pyclaragenomics/test/test_cudapoa_bindings.py
+++ b/pyclaragenomics/test/test_cudapoa_bindings.py
@@ -20,7 +20,8 @@ import claragenomics.bindings.cuda as cuda
 def test_cudapoa_simple_batch():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
-    batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device)
+    batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
+        output_mask='consensus')
     poa_1 = ["ACTGACTG", "ACTTACTG", "ACGGACTG", "ATCGACTG"]
     poa_2 = ["ACTGAC", "ACTTAC", "ACGGAC", "ATCGAC"]
     batch.add_poa_group(poa_1)
@@ -31,6 +32,26 @@ def test_cudapoa_simple_batch():
     assert(len(consensus) == 2)
     assert(batch.total_poas == 2)
 
+@pytest.mark.gpu
+def test_cudapoa_incorrect_output_type():
+    device = cuda.cuda_get_device()
+    free, total = cuda.cuda_get_mem_info(device)
+    try:
+        batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
+            output_type='error_input')
+        assert(False)
+    except RuntimeError:
+        pass
+
+@pytest.mark.gpu
+def test_cudapoa_valid_output_type():
+    device = cuda.cuda_get_device()
+    free, total = cuda.cuda_get_mem_info(device)
+    try:
+        batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
+            output_type='consensus')
+    except RuntimeError:
+        assert(False)
 
 @pytest.mark.gpu
 def test_cudapoa_reset_batch():

--- a/pyclaragenomics/test/test_cudapoa_bindings.py
+++ b/pyclaragenomics/test/test_cudapoa_bindings.py
@@ -20,8 +20,8 @@ import claragenomics.bindings.cuda as cuda
 def test_cudapoa_simple_batch():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
-    batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
-        output_mask='consensus')
+    batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device,
+                         output_mask='consensus')
     poa_1 = ["ACTGACTG", "ACTTACTG", "ACGGACTG", "ATCGACTG"]
     poa_2 = ["ACTGAC", "ACTTAC", "ACGGAC", "ATCGAC"]
     batch.add_poa_group(poa_1)
@@ -32,26 +32,29 @@ def test_cudapoa_simple_batch():
     assert(len(consensus) == 2)
     assert(batch.total_poas == 2)
 
+
 @pytest.mark.gpu
 def test_cudapoa_incorrect_output_type():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
     try:
-        batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
-            output_type='error_input')
+        CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device,
+                     output_type='error_input')
         assert(False)
     except RuntimeError:
         pass
+
 
 @pytest.mark.gpu
 def test_cudapoa_valid_output_type():
     device = cuda.cuda_get_device()
     free, total = cuda.cuda_get_mem_info(device)
     try:
-        batch = CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device, \
-            output_type='consensus')
+        CudaPoaBatch(10, 1024, 0.9 * free, deivce_id=device,
+                     output_type='consensus')
     except RuntimeError:
         assert(False)
+
 
 @pytest.mark.gpu
 def test_cudapoa_reset_batch():

--- a/pyclaragenomics/test/test_cudapoa_bindings.py
+++ b/pyclaragenomics/test/test_cudapoa_bindings.py
@@ -33,6 +33,24 @@ def test_cudapoa_simple_batch():
     assert(batch.total_poas == 2)
 
 
+def test_cudapoa_banded_aligned_batch():
+    device = cuda.cuda_get_device()
+    free, total = cuda.cuda_get_mem_info(device)
+    batch = CudaPoaBatch(10, 1024, 0.9 * free,
+                         deivce_id=device,
+                         output_mask='consensus',
+                         cuda_banded_alignment=True)
+    poa_1 = ["ACTGACTG", "ACTTACTG", "ACGGACTG", "ATCGACTG"]
+    poa_2 = ["ACTGAC", "ACTTAC", "ACGGAC", "ATCGAC"]
+    batch.add_poa_group(poa_1)
+    batch.add_poa_group(poa_2)
+    batch.generate_poa()
+    consensus, coverage, status = batch.get_consensus()
+
+    assert(len(consensus) == 2)
+    assert(batch.total_poas == 2)
+
+
 @pytest.mark.gpu
 def test_cudapoa_incorrect_output_type():
     device = cuda.cuda_get_device()


### PR DESCRIPTION
A previous MR has some changes to BatchSize structure and associated
API. However, it did not contain change required to use this structure
in other APIs.