### PR TITLE
[cudamapper] Removed info about reads from Index

### DIFF
--- a/common/io/include/claragenomics/io/fasta_parser.hpp
+++ b/common/io/include/claragenomics/io/fasta_parser.hpp
@@ -43,8 +43,8 @@ public:
 
     /// \brief Fetch an entry from the FASTA file by index position in file.
     /// \param sequence_id Position of sequence in file. If sequence_id is invalid an error is thrown.
-    /// \return A FastaSequence object describing the entry.
-    virtual FastaSequence get_sequence_by_id(read_id_t sequence_id) const = 0;
+    /// \return A reference to FastaSequence describing the entry.
+    virtual const FastaSequence& get_sequence_by_id(read_id_t sequence_id) const = 0;
 };
 
 /// \brief A builder function that returns a FASTA parser object which uses KSEQPP.

--- a/common/io/src/kseqpp_fasta_parser.cpp
+++ b/common/io/src/kseqpp_fasta_parser.cpp
@@ -64,7 +64,7 @@ number_of_reads_t FastaParserKseqpp::get_num_seqences() const
     return reads_.size();
 }
 
-FastaSequence FastaParserKseqpp::get_sequence_by_id(const read_id_t sequence_id) const
+const FastaSequence& FastaParserKseqpp::get_sequence_by_id(const read_id_t sequence_id) const
 {
     return reads_[sequence_id];
 }

--- a/common/io/src/kseqpp_fasta_parser.hpp
+++ b/common/io/src/kseqpp_fasta_parser.hpp
@@ -36,8 +36,8 @@ public:
 
     /// \brief Fetch an entry from the FASTA file by index position in file.
     /// \param sequence_id Position of sequence in file. If sequence_id is invalid an error is thrown.
-    /// \return A FastaSequence object describing the entry.
-    FastaSequence get_sequence_by_id(read_id_t sequence_id) const override;
+    /// \return A reference to FastaSequence describing the entry.
+    const FastaSequence& get_sequence_by_id(read_id_t sequence_id) const override;
 
 private:
     /// All the reads from the FASTA file are stored in host RAM

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -49,11 +49,6 @@ public:
     /// \return an array of directions in which sketch elements were read
     virtual const device_buffer<SketchElement::DirectionOfRepresentation>& directions_of_reads() const = 0;
 
-    /// \brief returns read name of read with the given read_id
-    /// \param read_id
-    /// \return read name of read with the given read_id
-    virtual const std::string& read_id_to_read_name(const read_id_t read_id) const = 0;
-
     /// \brief returns an array where each representation is recorder only once, sorted by representation
     /// \return an array where each representation is recorder only once, sorted by representation
     virtual const device_buffer<representation_t>& unique_representations() const = 0;
@@ -61,11 +56,6 @@ public:
     /// \brief returns first occurrence of corresponding representation from unique_representations() in data arrays
     /// \return first occurrence of corresponding representation from unique_representations() in data arrays
     virtual const device_buffer<std::uint32_t>& first_occurrence_of_representations() const = 0;
-
-    /// \brief returns read length for the read with the gived read_id
-    /// \param read_id
-    /// \return read length for the read with the gived read_id
-    virtual const std::uint32_t& read_id_to_read_length(const read_id_t read_id) const = 0;
 
     /// \brief returns number of reads in input data
     /// \return number of reads in input data

--- a/cudamapper/include/claragenomics/cudamapper/index.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/index.hpp
@@ -61,14 +61,6 @@ public:
     /// \return number of reads in input data
     virtual read_id_t number_of_reads() const = 0;
 
-    /// \brief returns look up table array mapping read id to read name
-    /// \return the array mapping read id to read name
-    virtual const std::vector<std::string>& read_ids_to_read_names() const = 0;
-
-    /// \brief returns an array used for mapping read id to the length of the read
-    /// \return the array used for mapping read ids to their lengths
-    virtual const std::vector<std::uint32_t>& read_ids_to_read_lengths() const = 0;
-
     /// \brief returns smallest read_id in index
     /// \return smallest read_id in index (0 if empty index)
     virtual read_id_t smallest_read_id() const = 0;
@@ -150,14 +142,6 @@ public:
     /// \brief returns first occurrence of corresponding representation from unique_representations(), plus one more element with the total number of sketch elements (stored on host)
     /// \return first occurrence of corresponding representation from unique_representations(), plus one more element with the total number of sketch elements
     virtual const std::vector<std::uint32_t>& first_occurrence_of_representations() const = 0;
-
-    /// \brief returns look up table array mapping read id to read name
-    /// \return the array mapping read id to read name
-    virtual const std::vector<std::string>& read_id_to_read_names() const = 0;
-
-    /// \brief returns an array used for mapping read id to the length of the read
-    /// \return the array used for mapping read ids to their lengths
-    virtual const std::vector<std::uint32_t>& read_id_to_read_lengths() const = 0;
 
     /// \brief returns number of reads in input data
     /// \return number of reads in input data

--- a/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
+++ b/cudamapper/include/claragenomics/cudamapper/overlapper.hpp
@@ -12,6 +12,7 @@
 
 #include <claragenomics/cudamapper/index.hpp>
 #include <claragenomics/cudamapper/types.hpp>
+#include <claragenomics/io/fasta_parser.hpp>
 
 #include <thrust/execution_policy.h>
 
@@ -63,11 +64,11 @@ public:
 
     /// \brief updates read names for vector of overlaps output from get_overlaps
     /// \param overlaps input vector of overlaps generated in get_overlaps
-    /// \param index_query
-    /// \param index_target
+    /// \param query_parser needed for read names and lenghts
+    /// \param target_parser needed for read names and lenghts
     static void update_read_names(std::vector<Overlap>& overlaps,
-                                  const Index& index_query,
-                                  const Index& index_target);
+                                  const io::FastaParser& query_parser,
+                                  const io::FastaParser& target_parser);
 
     /// \brief Identified overlaps which can be combined into a larger overlap and add them to the input vector
     /// \param overlaps reference to vector of Overlaps. New overlaps (result of fusing) are added to this vector

--- a/cudamapper/src/index_gpu.cuh
+++ b/cudamapper/src/index_gpu.cuh
@@ -105,19 +105,10 @@ public:
     /// \return first occurrence of corresponding representation from unique_representations() in data arrays, plus one more element with the total number of sketch elements
     const device_buffer<std::uint32_t>& first_occurrence_of_representations() const override;
 
-    /// \brief returns read name of read with the given read_id
-    /// \param read_id
-    /// \return read name of read with the given read_id
-    const std::string& read_id_to_read_name(const read_id_t read_id) const override;
-
-    /// \brief returns read length for the read with the gived read_id
-    /// \param read_id
-    /// \return read length for the read with the gived read_id
-    const std::uint32_t& read_id_to_read_length(const read_id_t read_id) const override;
-
     /// \brief returns look up table array mapping read id to read name
     /// \return the array mapping read id to read name
     const std::vector<std::string>& read_ids_to_read_names() const override;
+
     /// \brief returns an array used for mapping read id to the length of the read
     /// \return the array used for mapping read ids to their lengths
     const std::vector<std::uint32_t>& read_ids_to_read_lengths() const override;
@@ -684,18 +675,6 @@ template <typename SketchElementImpl>
 const device_buffer<std::uint32_t>& IndexGPU<SketchElementImpl>::first_occurrence_of_representations() const
 {
     return first_occurrence_of_representations_d_;
-}
-
-template <typename SketchElementImpl>
-const std::string& IndexGPU<SketchElementImpl>::read_id_to_read_name(const read_id_t read_id) const
-{
-    return read_id_to_read_name_[read_id - first_read_id_];
-}
-
-template <typename SketchElementImpl>
-const std::uint32_t& IndexGPU<SketchElementImpl>::read_id_to_read_length(const read_id_t read_id) const
-{
-    return read_id_to_read_length_[read_id - first_read_id_];
 }
 
 template <typename SketchElementImpl>

--- a/cudamapper/src/index_host_copy.cu
+++ b/cudamapper/src/index_host_copy.cu
@@ -65,9 +65,6 @@ IndexHostCopy::IndexHostCopy(const Index& index,
                              first_occurrence_of_representations_.data(),
                              cuda_stream);
 
-    read_id_to_read_name_   = index.read_ids_to_read_names();
-    read_id_to_read_length_ = index.read_ids_to_read_lengths();
-
     number_of_reads_                     = index.number_of_reads();
     number_of_basepairs_in_longest_read_ = index.number_of_basepairs_in_longest_read();
 
@@ -112,16 +109,6 @@ const std::vector<representation_t>& IndexHostCopy::unique_representations() con
 const std::vector<std::uint32_t>& IndexHostCopy::first_occurrence_of_representations() const
 {
     return first_occurrence_of_representations_;
-}
-
-const std::vector<std::string>& IndexHostCopy::read_id_to_read_names() const
-{
-    return read_id_to_read_name_;
-}
-
-const std::vector<std::uint32_t>& IndexHostCopy::read_id_to_read_lengths() const
-{
-    return read_id_to_read_length_;
 }
 
 read_id_t IndexHostCopy::number_of_reads() const

--- a/cudamapper/src/index_host_copy.cuh
+++ b/cudamapper/src/index_host_copy.cuh
@@ -67,14 +67,6 @@ public:
     /// \return first occurrence of corresponding representation from unique_representations(), plus one more element with the total number of sketch elements
     const std::vector<std::uint32_t>& first_occurrence_of_representations() const override;
 
-    /// \brief returns look up table array mapping read id to read name
-    /// \return the array mapping read id to read name
-    const std::vector<std::string>& read_id_to_read_names() const override;
-
-    /// \brief returns an array used for mapping read id to the length of the read
-    /// \return the array used for mapping read ids to their lengths
-    const std::vector<std::uint32_t>& read_id_to_read_lengths() const override;
-
     /// \brief returns number of reads in input data
     /// \return number of reads in input data
     read_id_t number_of_reads() const override;
@@ -103,9 +95,6 @@ private:
 
     std::vector<representation_t> unique_representations_;
     std::vector<std::uint32_t> first_occurrence_of_representations_;
-
-    std::vector<std::string> read_id_to_read_name_;
-    std::vector<std::uint32_t> read_id_to_read_length_;
 
     read_id_t number_of_reads_;
     position_in_read_t number_of_basepairs_in_longest_read_;

--- a/cudamapper/src/main.cu
+++ b/cudamapper/src/main.cu
@@ -387,15 +387,15 @@ void align_overlaps(DefaultDeviceAllocator allocator,
 /// @param overlaps_writer_mtx locked while writing the output
 /// @param num_overlap_chunks_to_print increased before the function is called, decreased right before the function finishes // TODO: improve this design
 /// @param filtered_overlaps overlaps to be written out, on input without read names, on output cleared
-/// @param query_index needed for read names // TODO: consider only passing vector of names, not whole indices
-/// @param target_index needed for read names // TODO: consider only passing vector of names, not whole indices
+/// @param query_parser needed for read names and lenghts
+/// @param target_parser needed for read names and lenghts
 /// @param cigar
 /// @param device_id id of device on which query and target indices were created
 void writer_thread_function(std::mutex& overlaps_writer_mtx,
                             std::atomic<int>& num_overlap_chunks_to_print,
                             std::shared_ptr<std::vector<Overlap>> filtered_overlaps,
-                            std::shared_ptr<Index> query_index,
-                            std::shared_ptr<Index> target_index,
+                            const io::FastaParser& query_parser,
+                            const io::FastaParser& target_parser,
                             const std::vector<std::string> cigar,
                             const int device_id,
                             const int kmer_size)
@@ -408,7 +408,7 @@ void writer_thread_function(std::mutex& overlaps_writer_mtx,
     Overlapper::post_process_overlaps(*filtered_overlaps);
 
     // parallel update of the query/target read names for filtered overlaps [parallel on host]
-    Overlapper::update_read_names(*filtered_overlaps, *query_index, *target_index);
+    Overlapper::update_read_names(*filtered_overlaps, query_parser, target_parser);
     std::lock_guard<std::mutex> lck(overlaps_writer_mtx);
     Overlapper::print_paf(*filtered_overlaps, cigar, kmer_size);
 
@@ -685,8 +685,8 @@ int main(int argc, char* argv[])
                               std::ref(overlaps_writer_mtx),
                               std::ref(num_overlap_chunks_to_print),
                               overlaps_to_add,
-                              query_index,
-                              target_index,
+                              std::ref(*query_parser),
+                              std::ref(*target_parser),
                               std::move(cigar),
                               device_id,
                               parameters.k);

--- a/cudamapper/src/overlapper.cpp
+++ b/cudamapper/src/overlapper.cpp
@@ -61,15 +61,15 @@ namespace cudamapper
 {
 
 void Overlapper::update_read_names(std::vector<Overlap>& overlaps,
-                                   const Index& index_query,
-                                   const Index& index_target)
+                                   const io::FastaParser& query_parser,
+                                   const io::FastaParser& target_parser)
 {
 #pragma omp parallel for
     for (size_t i = 0; i < overlaps.size(); i++)
     {
         auto& o                             = overlaps[i];
-        const std::string& query_read_name  = index_query.read_id_to_read_name(o.query_read_id_);
-        const std::string& target_read_name = index_target.read_id_to_read_name(o.target_read_id_);
+        const std::string& query_read_name  = query_parser.get_sequence_by_id(o.query_read_id_).name;
+        const std::string& target_read_name = target_parser.get_sequence_by_id(o.target_read_id_).name;
 
         o.query_read_name_ = new char[query_read_name.length() + 1];
         strcpy(o.query_read_name_, query_read_name.c_str());
@@ -77,8 +77,8 @@ void Overlapper::update_read_names(std::vector<Overlap>& overlaps,
         o.target_read_name_ = new char[target_read_name.length() + 1];
         strcpy(o.target_read_name_, target_read_name.c_str());
 
-        o.query_length_  = index_query.read_id_to_read_length(o.query_read_id_);
-        o.target_length_ = index_target.read_id_to_read_length(o.target_read_id_);
+        o.query_length_  = query_parser.get_sequence_by_id(o.query_read_id_).seq.length();
+        o.target_length_ = target_parser.get_sequence_by_id(o.target_read_id_).seq.length();
     }
 }
 

--- a/cudamapper/tests/Test_CudamapperIndexCache.cu
+++ b/cudamapper/tests/Test_CudamapperIndexCache.cu
@@ -36,8 +36,6 @@ void check_if_index_is_correct(const std::shared_ptr<Index>& index,
                                const std::vector<representation_t>& expected_unique_representations,
                                const std::vector<std::uint32_t>& expected_first_occurrence_of_representations,
                                const read_id_t expected_number_of_reads,
-                               const std::vector<std::string>& expected_read_ids_to_read_names,
-                               const std::vector<std::uint32_t>& expected_read_ids_to_read_lengths,
                                const read_id_t expected_smallest_read_id,
                                const read_id_t expected_largest_read_id,
                                const position_in_read_t expected_number_of_basepairs_in_longest_read,
@@ -49,8 +47,6 @@ void check_if_index_is_correct(const std::shared_ptr<Index>& index,
     ASSERT_EQ(get_size(expected_representations), get_size(expected_positions_in_reads)) << " test_uid: " << test_uid;
     ASSERT_EQ(get_size(expected_representations), get_size(expected_directions_of_reads)) << " test_uid: " << test_uid;
     ASSERT_EQ(get_size(expected_unique_representations), get_size(expected_first_occurrence_of_representations) - 1) << " test_uid: " << test_uid;
-    ASSERT_EQ(expected_number_of_reads, get_size(expected_read_ids_to_read_names)) << " test_uid: " << test_uid;
-    ASSERT_EQ(expected_number_of_reads, get_size(expected_read_ids_to_read_lengths)) << " test_uid: " << test_uid;
     ASSERT_LE(expected_number_of_reads, expected_largest_read_id - expected_smallest_read_id + 1) << " test_uid: " << test_uid;
 
     ASSERT_EQ(get_size(index->representations()), get_size(expected_representations)) << " test_uid: " << test_uid;
@@ -79,10 +75,6 @@ void check_if_index_is_correct(const std::shared_ptr<Index>& index,
 
     read_id_t index_number_of_reads = index->number_of_reads();
 
-    std::vector<std::string> index_read_ids_to_read_names = index->read_ids_to_read_names();
-
-    std::vector<std::uint32_t> index_read_ids_to_read_lengths = index->read_ids_to_read_lengths();
-
     read_id_t index_smallest_read_id = index->smallest_read_id();
 
     read_id_t index_largest_read_id = index->largest_read_id();
@@ -100,8 +92,6 @@ void check_if_index_is_correct(const std::shared_ptr<Index>& index,
     ASSERT_EQ(index_unique_representations, expected_unique_representations) << " test_uid: " << test_uid;
     ASSERT_EQ(index_first_occurrence_of_representations, expected_first_occurrence_of_representations) << " test_uid: " << test_uid;
     ASSERT_EQ(index_number_of_reads, expected_number_of_reads) << " test_uid: " << test_uid;
-    ASSERT_EQ(index_read_ids_to_read_names, expected_read_ids_to_read_names) << " test_uid: " << test_uid;
-    ASSERT_EQ(index_read_ids_to_read_lengths, expected_read_ids_to_read_lengths) << " test_uid: " << test_uid;
     ASSERT_EQ(index_smallest_read_id, expected_smallest_read_id) << " test_uid: " << test_uid;
     ASSERT_EQ(index_largest_read_id, expected_largest_read_id) << " test_uid: " << test_uid;
     ASSERT_EQ(index_number_of_basepairs_in_longest_read, expected_number_of_basepairs_in_longest_read) << " test_uid: " << test_uid;
@@ -257,9 +247,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
     // trailing elements
     aagcta_first_occurrence_of_representations.push_back(3);
 
-    const read_id_t aagcta_number_of_reads = 1;
-    const std::vector<std::string> aagcta_read_ids_to_read_names({"read_1"});
-    const std::vector<std::uint32_t> aagcta_read_ids_to_read_lengths({6});
+    const read_id_t aagcta_number_of_reads                              = 1;
     const read_id_t aagcta_smallest_read_id                             = 1;
     const read_id_t aagcta_largest_read_id                              = 1;
     const position_in_read_t aagcta_number_of_basepairs_in_longest_read = 6;
@@ -323,9 +311,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
     // trailing elements
     catcaag_aagcta_first_occurrence_of_representations.push_back(7);
 
-    const read_id_t catcaag_aagcta_number_of_reads = 2;
-    const std::vector<std::string> catcaag_aagcta_read_ids_to_read_names({"read_0", "read_1"});
-    const std::vector<std::uint32_t> catcaag_aagcta_read_ids_to_read_lengths({7, 6});
+    const read_id_t catcaag_aagcta_number_of_reads                              = 2;
     const read_id_t catcaag_aagcta_smallest_read_id                             = 0;
     const read_id_t catcaag_aagcta_largest_read_id                              = 1;
     const position_in_read_t catcaag_aagcta_number_of_basepairs_in_longest_read = 7;
@@ -362,8 +348,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -387,8 +371,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -407,8 +389,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -429,8 +409,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -448,8 +426,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -469,8 +445,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -486,8 +460,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -505,8 +477,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -526,8 +496,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -543,8 +511,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -563,8 +529,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_reuse_data)
                               catcaag_aagcta_unique_representations,
                               catcaag_aagcta_first_occurrence_of_representations,
                               catcaag_aagcta_number_of_reads,
-                              catcaag_aagcta_read_ids_to_read_names,
-                              catcaag_aagcta_read_ids_to_read_lengths,
                               catcaag_aagcta_smallest_read_id,
                               catcaag_aagcta_largest_read_id,
                               catcaag_aagcta_number_of_basepairs_in_longest_read,
@@ -670,9 +634,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_do_not_reuse_data)
     // trailing elements
     aagcta_first_occurrence_of_representations.push_back(3);
 
-    const read_id_t aagcta_number_of_reads = 1;
-    const std::vector<std::string> aagcta_read_ids_to_read_names({"read_0"});
-    const std::vector<std::uint32_t> aagcta_read_ids_to_read_lengths({6});
+    const read_id_t aagcta_number_of_reads                              = 1;
     const read_id_t aagcta_smallest_read_id                             = 0;
     const read_id_t aagcta_largest_read_id                              = 0;
     const position_in_read_t aagcta_number_of_basepairs_in_longest_read = 6;
@@ -717,9 +679,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_do_not_reuse_data)
     // trailing elements
     catcaag_first_occurrence_of_representations.push_back(4);
 
-    const read_id_t catcaag_number_of_reads = 1;
-    const std::vector<std::string> catcaag_read_ids_to_read_names({"read_0"});
-    const std::vector<std::uint32_t> catcaag_read_ids_to_read_lengths({7});
+    const read_id_t catcaag_number_of_reads                              = 1;
     const read_id_t catcaag_smallest_read_id                             = 0;
     const read_id_t catcaag_largest_read_id                              = 0;
     const position_in_read_t catcaag_number_of_basepairs_in_longest_read = 7;
@@ -752,8 +712,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_do_not_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -773,8 +731,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_do_not_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -790,8 +746,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_host_do_not_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -868,9 +822,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_reuse_data)
     // trailing elements
     catcaag_first_occurrence_of_representations.push_back(4);
 
-    const read_id_t catcaag_number_of_reads = 1;
-    const std::vector<std::string> catcaag_read_ids_to_read_names({"read_0"});
-    const std::vector<std::uint32_t> catcaag_read_ids_to_read_lengths({7});
+    const read_id_t catcaag_number_of_reads                              = 1;
     const read_id_t catcaag_smallest_read_id                             = 0;
     const read_id_t catcaag_largest_read_id                              = 0;
     const position_in_read_t catcaag_number_of_basepairs_in_longest_read = 7;
@@ -908,9 +860,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_reuse_data)
     // trailing elements
     aagcta_first_occurrence_of_representations.push_back(3);
 
-    const read_id_t aagcta_number_of_reads = 1;
-    const std::vector<std::string> aagcta_read_ids_to_read_names({"read_1"});
-    const std::vector<std::uint32_t> aagcta_read_ids_to_read_lengths({6});
+    const read_id_t aagcta_number_of_reads                              = 1;
     const read_id_t aagcta_smallest_read_id                             = 1;
     const read_id_t aagcta_largest_read_id                              = 1;
     const position_in_read_t aagcta_number_of_basepairs_in_longest_read = 6;
@@ -949,8 +899,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -976,8 +924,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,
@@ -994,8 +940,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -1058,9 +1002,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_do_not_reuse_data)
     // trailing elements
     aagcta_first_occurrence_of_representations.push_back(3);
 
-    const read_id_t aagcta_number_of_reads = 1;
-    const std::vector<std::string> aagcta_read_ids_to_read_names({"read_0"});
-    const std::vector<std::uint32_t> aagcta_read_ids_to_read_lengths({6});
+    const read_id_t aagcta_number_of_reads                              = 1;
     const read_id_t aagcta_smallest_read_id                             = 0;
     const read_id_t aagcta_largest_read_id                              = 0;
     const position_in_read_t aagcta_number_of_basepairs_in_longest_read = 6;
@@ -1105,9 +1047,7 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_do_not_reuse_data)
     // trailing elements
     catcaag_first_occurrence_of_representations.push_back(4);
 
-    const read_id_t catcaag_number_of_reads = 1;
-    const std::vector<std::string> catcaag_read_ids_to_read_names({"read_0"});
-    const std::vector<std::uint32_t> catcaag_read_ids_to_read_lengths({7});
+    const read_id_t catcaag_number_of_reads                              = 1;
     const read_id_t catcaag_smallest_read_id                             = 0;
     const read_id_t catcaag_largest_read_id                              = 0;
     const position_in_read_t catcaag_number_of_basepairs_in_longest_read = 7;
@@ -1146,8 +1086,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_do_not_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -1172,8 +1110,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_do_not_reuse_data)
                               aagcta_unique_representations,
                               aagcta_first_occurrence_of_representations,
                               aagcta_number_of_reads,
-                              aagcta_read_ids_to_read_names,
-                              aagcta_read_ids_to_read_lengths,
                               aagcta_smallest_read_id,
                               aagcta_largest_read_id,
                               aagcta_number_of_basepairs_in_longest_read,
@@ -1188,8 +1124,6 @@ TEST(TestCudamapperIndexCaching, test_index_cache_device_do_not_reuse_data)
                               catcaag_unique_representations,
                               catcaag_first_occurrence_of_representations,
                               catcaag_number_of_reads,
-                              catcaag_read_ids_to_read_names,
-                              catcaag_read_ids_to_read_lengths,
                               catcaag_smallest_read_id,
                               catcaag_largest_read_id,
                               catcaag_number_of_basepairs_in_longest_read,

--- a/cudamapper/tests/Test_CudamapperIndexGPU.cu
+++ b/cudamapper/tests/Test_CudamapperIndexGPU.cu
@@ -1344,8 +1344,6 @@ void test_function(const std::string& filename,
                    const std::vector<SketchElement::DirectionOfRepresentation>& expected_directions_of_reads,
                    const std::vector<representation_t>& expected_unique_representations,
                    const std::vector<std::uint32_t>& expected_first_occurrence_of_representations,
-                   const std::vector<std::string>& expected_read_id_to_read_name,
-                   const std::vector<std::uint32_t>& expected_read_id_to_read_length,
                    const read_id_t expected_number_of_reads,
                    const position_in_read_t expected_number_of_basepairs_in_longest_read,
                    const double filtering_parameter = 1.0)
@@ -1378,14 +1376,6 @@ void test_function(const std::string& filename,
         ASSERT_EQ(index.largest_read_id(), expected_largest_read_id);
 
         ASSERT_EQ(expected_number_of_basepairs_in_longest_read, index.number_of_basepairs_in_longest_read());
-
-        ASSERT_EQ(expected_number_of_reads, expected_read_id_to_read_name.size());
-        ASSERT_EQ(expected_number_of_reads, expected_read_id_to_read_length.size());
-        for (read_id_t read_id = first_read_id; read_id < past_the_last_read_id; ++read_id)
-        {
-            ASSERT_EQ(index.read_id_to_read_length(read_id), expected_read_id_to_read_length[read_id - first_read_id]) << "read_id: " << read_id;
-            ASSERT_EQ(index.read_id_to_read_name(read_id), expected_read_id_to_read_name[read_id - first_read_id]) << "read_id: " << read_id;
-        }
 
         // check arrays
         const device_buffer<representation_t>& representations_d                             = index.representations();
@@ -1449,12 +1439,6 @@ TEST(TestCudamapperIndexGPU, GATT_4_1)
     const std::uint64_t minimizer_size = 4;
     const std::uint64_t window_size    = 1;
 
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(4);
-
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
     std::vector<read_id_t> expected_read_ids;
@@ -1489,8 +1473,6 @@ TEST(TestCudamapperIndexGPU, GATT_4_1)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -1527,12 +1509,6 @@ TEST(TestCudamapperIndexGPU, GATT_2_3)
     const std::string filename         = std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/gatt.fasta";
     const std::uint64_t minimizer_size = 2;
     const std::uint64_t window_size    = 3;
-
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(4);
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -1580,8 +1556,6 @@ TEST(TestCudamapperIndexGPU, GATT_2_3)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -1598,10 +1572,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
     const std::uint64_t window_size    = 8;
 
     // all data arrays should be empty
-
-    std::vector<std::string> expected_read_id_to_read_name;
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -1628,8 +1598,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -1683,12 +1651,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
 //    const std::uint64_t minimizer_size = 3;
 //    const std::uint64_t window_size    = 5;
 //
-//    std::vector<std::string> expected_read_id_to_read_name;
-//    expected_read_id_to_read_name.push_back("read_0");
-//
-//    std::vector<std::uint32_t> expected_read_id_to_read_length;
-//    expected_read_id_to_read_length.push_back(7);
-//
 //    std::vector<representation_t> expected_representations;
 //    std::vector<position_in_read_t> expected_positions_in_reads;
 //    std::vector<read_id_t> expected_read_ids;
@@ -1718,8 +1680,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_2_8)
 //                  expected_positions_in_reads,
 //                  expected_read_ids,
 //                  expected_directions_of_reads,
-//                  expected_read_id_to_read_name,
-//                  expected_read_id_to_read_length,
 //                  expected_number_of_reads,
 //                  expected_number_of_basepairs_in_longest_read); // <- only one read goes into index, the other is too short
 //}
@@ -1766,12 +1726,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_3_5)
     const std::string filename         = std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/cccatacc.fasta";
     const std::uint64_t minimizer_size = 3;
     const std::uint64_t window_size    = 5;
-
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(8);
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -1831,8 +1785,6 @@ TEST(TestCudamapperIndexGPU, CCCATACC_3_5)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -1897,14 +1849,6 @@ TEST(TestCudamapperIndexGPU, CATCAAG_AAGCTA_3_2)
     const std::string filename         = std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/catcaag_aagcta.fasta";
     const std::uint64_t minimizer_size = 3;
     const std::uint64_t window_size    = 2;
-
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-    expected_read_id_to_read_name.push_back("read_1");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(7);
-    expected_read_id_to_read_length.push_back(6);
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -1974,8 +1918,6 @@ TEST(TestCudamapperIndexGPU, CATCAAG_AAGCTA_3_2)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -2052,14 +1994,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3)
     const std::string filename         = std::string(CUDAMAPPER_BENCHMARK_DATA_DIR) + "/aaaactgaa_gccaaag.fasta";
     const std::uint64_t minimizer_size = 2;
     const std::uint64_t window_size    = 3;
-
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-    expected_read_id_to_read_name.push_back("read_1");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(9);
-    expected_read_id_to_read_length.push_back(7);
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -2149,8 +2083,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -2202,11 +2134,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_only_second_read_in_index)
     const std::uint64_t window_size    = 3;
 
     // only take second read
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_1");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(7);
 
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
@@ -2270,8 +2197,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_only_second_read_in_index)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read);
 }
@@ -2355,14 +2280,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_filtering)
     const std::uint64_t window_size    = 3;
     const double filtering_parameter   = 0.5;
 
-    std::vector<std::string> expected_read_id_to_read_name;
-    expected_read_id_to_read_name.push_back("read_0");
-    expected_read_id_to_read_name.push_back("read_1");
-
-    std::vector<std::uint32_t> expected_read_id_to_read_length;
-    expected_read_id_to_read_length.push_back(9);
-    expected_read_id_to_read_length.push_back(7);
-
     std::vector<representation_t> expected_representations;
     std::vector<position_in_read_t> expected_positions_in_reads;
     std::vector<read_id_t> expected_read_ids;
@@ -2425,8 +2342,6 @@ TEST(TestCudamapperIndexGPU, AAAACTGAA_GCCAAAG_2_3_filtering)
                   expected_directions_of_reads,
                   expected_unique_representations,
                   expected_first_occurrence_of_representations,
-                  expected_read_id_to_read_name,
-                  expected_read_id_to_read_length,
                   expected_number_of_reads,
                   expected_number_of_basepairs_in_longest_read,
                   filtering_parameter);

--- a/cudamapper/tests/mock_fasta_parser.hpp
+++ b/cudamapper/tests/mock_fasta_parser.hpp
@@ -1,0 +1,30 @@
+/*
+* Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+*
+* NVIDIA CORPORATION and its licensors retain all intellectual property
+* and proprietary rights in and to this software, related documentation
+* and any modifications thereto.  Any use, reproduction, disclosure or
+* distribution of this software and related documentation without an express
+* license agreement from NVIDIA CORPORATION is strictly prohibited.
+*/
+
+#pragma once
+
+#include "gmock/gmock.h"
+
+#include <claragenomics/io/fasta_parser.hpp>
+
+namespace claragenomics
+{
+namespace cudamapper
+{
+
+class MockFastaParser : public io::FastaParser
+{
+public:
+    MOCK_METHOD(number_of_reads_t, get_num_seqences, (), (const, override));
+    MOCK_METHOD(const io::FastaSequence&, get_sequence_by_id, (read_id_t sequence_id), (const, override));
+};
+
+} // namespace cudamapper
+} // namespace claragenomics

--- a/cudamapper/tests/mock_index.cuh
+++ b/cudamapper/tests/mock_index.cuh
@@ -39,9 +39,7 @@ public:
 
     MOCK_METHOD(device_buffer<read_id_t>&, read_ids, (), (const, override));
     MOCK_METHOD(device_buffer<position_in_read_t>&, positions_in_reads, (), (const, override));
-    MOCK_METHOD(const std::string&, read_id_to_read_name, (const read_id_t read_id), (const, override));
     MOCK_METHOD(device_buffer<std::uint32_t>&, first_occurrence_of_representations, (), (const, override));
-    MOCK_METHOD(const std::uint32_t&, read_id_to_read_length, (const read_id_t read_id), (const, override));
     MOCK_METHOD(read_id_t, number_of_reads, (), (const, override));
     MOCK_METHOD(read_id_t, smallest_read_id, (), (const, override));
     MOCK_METHOD(read_id_t, largest_read_id, (), (const, override));


### PR DESCRIPTION
`Index` contained functions for converting `read_id` into read name and read length. This information if already available in `FastaParser` and is only used on host side when adding read names to `Overlap`s.

This also meant that a copy of `Index` had to be kept until `Overlap`s had been written to output, which is done on a separate host-only thread. This resulted in keeping two sets of indices: the one which is currently being processed and the one which has already been processed and is being written to output, which both increased memory consumption and lead to memory fragmentation.

The following functions have been removed, as well as underlying data structures:
`Index::read_id_to_read_name()`
`Index::read_id_to_read_length()`
`Index::read_ids_to_read_names()`
`Index::read_ids_to_read_lengths()`
`IndexHostCopyBase::read_id_to_read_names()`
`IndexHostCopyBase::read_id_to_read_lengths()`

In addition to this `FastaParser::get_sequence_by_id()` has been modified to return by reference, not by value.

All this allowed `Overlapper::update_read_names()` to accept `FastaParser` instead of `Index` and thus do not require keeping device data which it anyway did not use.

Note that `update_read_name()` probably belongs more to `Overlap` than to `Overlapper`, but this is something that will be refactored in another PR.

This PR is part of Issue #318 